### PR TITLE
Add cluster.yaml and release channel switching

### DIFF
--- a/.devcontainer/generacy/.env.template
+++ b/.devcontainer/generacy/.env.template
@@ -17,13 +17,16 @@ REPO_NAME=
 # Branch to clone (default: main)
 REPO_BRANCH=main
 
-# Number of worker containers (default: 3)
+# Number of worker containers
+# Overrides workers.count in .generacy/cluster.yaml when set
 WORKER_COUNT=3
 
 # Orchestrator port (default: 3100)
 ORCHESTRATOR_PORT=3100
 
-# Generacy release chanel (default: preview)
+# Generacy release channel
+# Overrides channel in .generacy/cluster.yaml when set
+# Switch with: .generacy/switch-channel.sh <preview|stable>
 GENERACY_CHANNEL=preview
 
 # Smee.io channel URL for GitHub webhook forwarding

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -14,6 +14,10 @@ bash /usr/local/bin/setup-credentials.sh
 # Resolve workspace directory (handles devcontainer detection + clone)
 source /usr/local/bin/resolve-workspace.sh
 
+# Load cluster.yaml defaults (sets GENERACY_CHANNEL, WORKER_COUNT, WORKERS_ENABLED
+# if not already provided via .env or environment)
+source /usr/local/bin/load-cluster-config.sh
+
 # Install generacy/agency packages into shared volume
 SHARED_PACKAGES=/shared-packages
 CHANNEL="${GENERACY_CHANNEL:-stable}"

--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -16,6 +16,10 @@ bash /usr/local/bin/setup-credentials.sh
 # Resolve workspace directory (handles devcontainer detection + clone)
 source /usr/local/bin/resolve-workspace.sh
 
+# Load cluster.yaml defaults (sets GENERACY_CHANNEL, WORKER_COUNT, WORKERS_ENABLED
+# if not already provided via .env or environment)
+source /usr/local/bin/load-cluster-config.sh
+
 # Set up CLI wrappers pointing to shared packages volume
 SHARED_PACKAGES=/shared-packages
 LOCAL_BIN="${HOME}/.local/bin"

--- a/.devcontainer/generacy/scripts/load-cluster-config.sh
+++ b/.devcontainer/generacy/scripts/load-cluster-config.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Load cluster configuration from .generacy/cluster.yaml
+#
+# Reads cluster.yaml and exports environment variables for values
+# not already set by .env or the shell environment. This allows
+# .env overrides to take precedence over cluster.yaml defaults.
+#
+# Exported variables:
+#   WORKER_COUNT       — from workers.count (default: 3)
+#   WORKERS_ENABLED    — from workers.enabled (default: true)
+#   GENERACY_CHANNEL   — from channel (default: stable)
+#
+# Usage: source /usr/local/bin/load-cluster-config.sh
+#   Requires WORKSPACE_DIR to be set (by resolve-workspace.sh).
+
+_cluster_log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [cluster-config] $*"
+}
+
+CLUSTER_YAML="${WORKSPACE_DIR:-.}/.generacy/cluster.yaml"
+
+if [ ! -f "$CLUSTER_YAML" ]; then
+    _cluster_log "No cluster.yaml found at ${CLUSTER_YAML} — using environment defaults"
+    return 0 2>/dev/null || exit 0
+fi
+
+_cluster_log "Loading cluster config from ${CLUSTER_YAML}"
+
+# Parse simple YAML values (flat keys and one-level nested keys).
+# This avoids requiring js-yaml or python in the entrypoint path.
+_yaml_value() {
+    local key="$1"
+    grep -E "^\s*${key}:" "$CLUSTER_YAML" 2>/dev/null \
+        | head -1 \
+        | sed 's/^[^:]*:[[:space:]]*//' \
+        | sed 's/[[:space:]]*#.*//' \
+        | tr -d '"'"'"
+}
+
+# Channel
+_val=$(_yaml_value "channel")
+if [ -n "$_val" ]; then
+    if [ -z "${GENERACY_CHANNEL:-}" ]; then
+        export GENERACY_CHANNEL="$_val"
+        _cluster_log "Set GENERACY_CHANNEL=${_val} (from cluster.yaml)"
+    else
+        if [ "$GENERACY_CHANNEL" != "$_val" ]; then
+            _cluster_log "GENERACY_CHANNEL=${GENERACY_CHANNEL} (env override; cluster.yaml has ${_val})"
+        fi
+    fi
+fi
+
+# Worker count
+_val=$(_yaml_value "count")
+if [ -n "$_val" ]; then
+    if [ -z "${WORKER_COUNT:-}" ]; then
+        export WORKER_COUNT="$_val"
+        _cluster_log "Set WORKER_COUNT=${_val} (from cluster.yaml)"
+    else
+        if [ "$WORKER_COUNT" != "$_val" ]; then
+            _cluster_log "WORKER_COUNT=${WORKER_COUNT} (env override; cluster.yaml has ${_val})"
+        fi
+    fi
+fi
+
+# Workers enabled
+_val=$(_yaml_value "enabled")
+if [ -n "$_val" ]; then
+    export WORKERS_ENABLED="$_val"
+    _cluster_log "Set WORKERS_ENABLED=${_val} (from cluster.yaml)"
+fi
+
+unset _val _yaml_value _cluster_log

--- a/.generacy/README.md
+++ b/.generacy/README.md
@@ -56,6 +56,44 @@ The setup script walks you through configuring the cluster interactively:
 - Updates `devcontainer.json` with your project name and workspace path
 - Ensures `~/.claude.json` exists on your host (required for the Docker volume mount)
 
+## Cluster Configuration
+
+The file `.generacy/cluster.yaml` is the declarative source of truth for cluster settings. The orchestrator and workers read it on startup to determine default values for channel, worker count, and worker state.
+
+```yaml
+channel: stable          # preview | stable
+workers:
+  count: 3               # number of worker containers
+  enabled: true          # global worker enable/disable
+```
+
+**How defaults work**: Values in `.env` override `cluster.yaml`. If `GENERACY_CHANNEL` or `WORKER_COUNT` are set in `.env`, those take precedence. If not, the values from `cluster.yaml` are used.
+
+### Switching Release Channels
+
+Use the channel switching script to move between `stable` (production releases, tracks `main`) and `preview` (latest features, tracks `develop`):
+
+```bash
+# macOS / Linux / WSL
+.generacy/switch-channel.sh preview
+.generacy/switch-channel.sh stable
+
+# Windows PowerShell
+.generacy\switch-channel.ps1 preview
+.generacy\switch-channel.ps1 stable
+```
+
+The script will:
+1. Add/verify the `cluster-base` git remote
+2. Fetch and merge the target branch (`main` for stable, `develop` for preview)
+3. Update `cluster.yaml`, `.env.template`, and `.env` with the new channel
+4. Print next steps (rebuild containers to apply)
+
+**Manual channel switch** (without the script):
+1. Edit `.generacy/cluster.yaml` — set `channel: preview` or `channel: stable`
+2. Edit `.devcontainer/generacy/.env` — set `GENERACY_CHANNEL=preview` or `GENERACY_CHANNEL=stable`
+3. Rebuild: `cd .devcontainer/generacy && docker compose up -d --build`
+
 ## What's Included
 
 - **Orchestrator** — manages worker lifecycle, dispatches label-driven workflows
@@ -111,8 +149,11 @@ Git merge handles conflicts naturally if you've customized any base files.
     .env.local.template   # Reference for user secrets
     scripts/              # Entrypoint and setup scripts
 .generacy/
+  cluster.yaml            # Cluster configuration (channel, workers)
   setup.sh                # Setup script (bash)
   setup.ps1               # Setup script (PowerShell)
+  switch-channel.sh       # Channel switching (bash)
+  switch-channel.ps1      # Channel switching (PowerShell)
   README.md               # This file
   speckit-feature.yaml    # Feature development workflow
   speckit-bugfix.yaml     # Bugfix workflow

--- a/.generacy/cluster.yaml
+++ b/.generacy/cluster.yaml
@@ -1,0 +1,17 @@
+# Generacy Cluster Configuration
+#
+# This file is the declarative source of truth for cluster settings.
+# The orchestrator reads it on startup; changes take effect on restart
+# (or immediately for settings the orchestrator watches at runtime).
+
+channel: stable          # preview | stable — determines package versions and update source
+
+workers:
+  count: 3               # number of worker containers
+  enabled: true          # global worker enable/disable
+
+# Future extension points (not yet implemented):
+# resources:
+#   memory_limit: "4g"
+# plugins:
+#   enabled: []

--- a/.generacy/switch-channel.ps1
+++ b/.generacy/switch-channel.ps1
@@ -1,0 +1,129 @@
+# Switch Generacy release channel (preview / stable)
+#
+# Updates the cluster-base remote to track the appropriate branch,
+# pulls the latest changes, and updates local configuration files.
+#
+# Usage:
+#   .generacy\switch-channel.ps1 preview
+#   .generacy\switch-channel.ps1 stable
+
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet("preview", "stable")]
+    [string]$Channel
+)
+
+$ErrorActionPreference = "Stop"
+$ProjectDir = Split-Path $PSScriptRoot -Parent
+$ClusterYaml = Join-Path $PSScriptRoot "cluster.yaml"
+$EnvTemplate = Join-Path $ProjectDir ".devcontainer" "generacy" ".env.template"
+$EnvFile = Join-Path $ProjectDir ".devcontainer" "generacy" ".env"
+
+# -- Helpers ------------------------------------------------------------------
+
+function Write-Info { Write-Host "==> $args" -ForegroundColor Blue }
+function Write-Ok   { Write-Host "  + $args" -ForegroundColor Green }
+function Write-Warn { Write-Host "  ! $args" -ForegroundColor Yellow }
+function Write-Err  { Write-Host "  x $args" -ForegroundColor Red }
+
+# -- Map channel to branch ----------------------------------------------------
+
+if ($Channel -eq "preview") {
+    $Branch = "develop"
+} else {
+    $Branch = "main"
+}
+
+Write-Info "Switching to '$Channel' channel (branch: $Branch)"
+
+# -- Step 1: Update cluster-base remote ---------------------------------------
+
+$Remote = "cluster-base"
+
+$remoteUrl = git remote get-url $Remote 2>$null
+if ($LASTEXITCODE -eq 0 -and $remoteUrl) {
+    Write-Ok "Remote '$Remote' exists"
+} else {
+    Write-Info "Adding remote '$Remote'..."
+    git remote add $Remote "https://github.com/generacy-ai/cluster-base.git"
+    Write-Ok "Added remote '$Remote'"
+}
+
+# -- Step 2: Fetch from the target branch --------------------------------------
+
+Write-Info "Fetching $Remote/$Branch..."
+git fetch $Remote $Branch
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "Failed to fetch $Remote/$Branch"
+    exit 1
+}
+Write-Ok "Fetched $Remote/$Branch"
+
+# -- Step 3: Merge changes ----------------------------------------------------
+
+Write-Info "Merging $Remote/$Branch..."
+
+git merge "$Remote/$Branch" --allow-unrelated-histories -m "chore: switch to $Channel channel (merge $Remote/$Branch)" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warn "Merge had conflicts - resolve them manually, then re-run this script"
+    Write-Warn "Or run: git merge --abort  to undo"
+    exit 1
+}
+Write-Ok "Merged $Remote/$Branch"
+
+# -- Step 4: Update cluster.yaml ----------------------------------------------
+
+if (Test-Path $ClusterYaml) {
+    Write-Info "Updating cluster.yaml..."
+    $content = Get-Content -Path $ClusterYaml -Raw
+    $content = $content -replace '(?m)^channel:.*$', "channel: $Channel"
+    Set-Content -Path $ClusterYaml -Value $content -NoNewline
+    Write-Ok "cluster.yaml channel set to '$Channel'"
+} else {
+    Write-Warn "cluster.yaml not found at $ClusterYaml - skipping"
+}
+
+# -- Step 5: Update .env.template ---------------------------------------------
+
+if (Test-Path $EnvTemplate) {
+    Write-Info "Updating .env.template..."
+    $content = Get-Content -Path $EnvTemplate -Raw
+    $content = $content -replace '(?m)^GENERACY_CHANNEL=.*$', "GENERACY_CHANNEL=$Channel"
+    Set-Content -Path $EnvTemplate -Value $content -NoNewline
+    Write-Ok ".env.template GENERACY_CHANNEL set to '$Channel'"
+} else {
+    Write-Warn ".env.template not found at $EnvTemplate - skipping"
+}
+
+# -- Step 6: Update .env (if it exists) ----------------------------------------
+
+if (Test-Path $EnvFile) {
+    Write-Info "Updating .env..."
+    $content = Get-Content -Path $EnvFile -Raw
+    if ($content -match '(?m)^GENERACY_CHANNEL=') {
+        $content = $content -replace '(?m)^GENERACY_CHANNEL=.*$', "GENERACY_CHANNEL=$Channel"
+        Set-Content -Path $EnvFile -Value $content -NoNewline
+        Write-Ok ".env GENERACY_CHANNEL set to '$Channel'"
+    } else {
+        Add-Content -Path $EnvFile -Value "GENERACY_CHANNEL=$Channel"
+        Write-Ok "Added GENERACY_CHANNEL=$Channel to .env"
+    }
+}
+
+# -- Summary -------------------------------------------------------------------
+
+Write-Host ""
+Write-Info "Channel switch complete!"
+Write-Host ""
+Write-Host "  Channel:  $Channel"
+Write-Host "  Branch:   $Remote/$Branch"
+Write-Host "  Changed:"
+if (Test-Path $ClusterYaml) { Write-Host "    .generacy/cluster.yaml             -> channel: $Channel" }
+if (Test-Path $EnvTemplate) { Write-Host "    .devcontainer/generacy/.env.template -> GENERACY_CHANNEL=$Channel" }
+if (Test-Path $EnvFile)     { Write-Host "    .devcontainer/generacy/.env          -> GENERACY_CHANNEL=$Channel" }
+Write-Host ""
+Write-Host "  Next steps:"
+Write-Host "    1. Rebuild containers to apply the new channel:"
+Write-Host "       cd .devcontainer/generacy; docker compose up -d --build"
+Write-Host "    2. Commit the updated configuration files"
+Write-Host ""

--- a/.generacy/switch-channel.sh
+++ b/.generacy/switch-channel.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Switch Generacy release channel (preview ↔ stable)
+#
+# Updates the cluster-base remote to track the appropriate branch,
+# pulls the latest changes, and updates local configuration files.
+#
+# Usage:
+#   .generacy/switch-channel.sh preview
+#   .generacy/switch-channel.sh stable
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLUSTER_YAML="${SCRIPT_DIR}/cluster.yaml"
+ENV_TEMPLATE="${PROJECT_DIR}/.devcontainer/generacy/.env.template"
+ENV_FILE="${PROJECT_DIR}/.devcontainer/generacy/.env"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+info()  { echo -e "\033[1;34m==>\033[0m $*"; }
+ok()    { echo -e "\033[1;32m  ✓\033[0m $*"; }
+warn()  { echo -e "\033[1;33m  !\033[0m $*"; }
+error() { echo -e "\033[1;31m  ✗\033[0m $*"; }
+
+# ── Validate arguments ──────────────────────────────────────────────────────
+
+CHANNEL="${1:-}"
+
+if [ -z "$CHANNEL" ]; then
+    echo "Usage: .generacy/switch-channel.sh <preview|stable>"
+    echo ""
+    echo "Channels:"
+    echo "  stable   — production-ready releases (tracks cluster-base/main)"
+    echo "  preview  — latest features and fixes (tracks cluster-base/develop)"
+    exit 1
+fi
+
+if [ "$CHANNEL" != "preview" ] && [ "$CHANNEL" != "stable" ]; then
+    error "Invalid channel: ${CHANNEL}"
+    echo "  Valid channels: preview, stable"
+    exit 1
+fi
+
+# Map channel to branch
+if [ "$CHANNEL" = "preview" ]; then
+    BRANCH="develop"
+else
+    BRANCH="main"
+fi
+
+info "Switching to '${CHANNEL}' channel (branch: ${BRANCH})"
+
+# ── Step 1: Update cluster-base remote ──────────────────────────────────────
+
+REMOTE="cluster-base"
+
+if git remote get-url "$REMOTE" >/dev/null 2>&1; then
+    ok "Remote '${REMOTE}' exists"
+else
+    info "Adding remote '${REMOTE}'..."
+    git remote add "$REMOTE" https://github.com/generacy-ai/cluster-base.git
+    ok "Added remote '${REMOTE}'"
+fi
+
+# ── Step 2: Fetch from the target branch ────────────────────────────────────
+
+info "Fetching ${REMOTE}/${BRANCH}..."
+git fetch "$REMOTE" "$BRANCH"
+ok "Fetched ${REMOTE}/${BRANCH}"
+
+# ── Step 3: Merge changes ──────────────────────────────────────────────────
+
+info "Merging ${REMOTE}/${BRANCH}..."
+
+if git merge "${REMOTE}/${BRANCH}" --allow-unrelated-histories -m "chore: switch to ${CHANNEL} channel (merge ${REMOTE}/${BRANCH})" 2>/dev/null; then
+    ok "Merged ${REMOTE}/${BRANCH}"
+else
+    warn "Merge had conflicts — resolve them manually, then re-run this script"
+    warn "Or run: git merge --abort  to undo"
+    exit 1
+fi
+
+# ── Step 4: Update cluster.yaml ─────────────────────────────────────────────
+
+if [ -f "$CLUSTER_YAML" ]; then
+    info "Updating cluster.yaml..."
+    sed -i.bak "s/^channel:.*$/channel: ${CHANNEL}/" "$CLUSTER_YAML"
+    rm -f "${CLUSTER_YAML}.bak"
+    ok "cluster.yaml channel set to '${CHANNEL}'"
+else
+    warn "cluster.yaml not found at ${CLUSTER_YAML} — skipping"
+fi
+
+# ── Step 5: Update .env.template ────────────────────────────────────────────
+
+if [ -f "$ENV_TEMPLATE" ]; then
+    info "Updating .env.template..."
+    sed -i.bak "s/^GENERACY_CHANNEL=.*$/GENERACY_CHANNEL=${CHANNEL}/" "$ENV_TEMPLATE"
+    rm -f "${ENV_TEMPLATE}.bak"
+    ok ".env.template GENERACY_CHANNEL set to '${CHANNEL}'"
+else
+    warn ".env.template not found at ${ENV_TEMPLATE} — skipping"
+fi
+
+# ── Step 6: Update .env (if it exists) ──────────────────────────────────────
+
+if [ -f "$ENV_FILE" ]; then
+    info "Updating .env..."
+    if grep -q '^GENERACY_CHANNEL=' "$ENV_FILE"; then
+        sed -i.bak "s/^GENERACY_CHANNEL=.*$/GENERACY_CHANNEL=${CHANNEL}/" "$ENV_FILE"
+        rm -f "${ENV_FILE}.bak"
+        ok ".env GENERACY_CHANNEL set to '${CHANNEL}'"
+    else
+        echo "GENERACY_CHANNEL=${CHANNEL}" >> "$ENV_FILE"
+        ok "Added GENERACY_CHANNEL=${CHANNEL} to .env"
+    fi
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+info "Channel switch complete!"
+echo ""
+echo "  Channel:  ${CHANNEL}"
+echo "  Branch:   ${REMOTE}/${BRANCH}"
+echo "  Changed:"
+[ -f "$CLUSTER_YAML" ] && echo "    .generacy/cluster.yaml           → channel: ${CHANNEL}"
+[ -f "$ENV_TEMPLATE" ] && echo "    .devcontainer/generacy/.env.template → GENERACY_CHANNEL=${CHANNEL}"
+[ -f "$ENV_FILE" ]     && echo "    .devcontainer/generacy/.env          → GENERACY_CHANNEL=${CHANNEL}"
+echo ""
+echo "  Next steps:"
+echo "    1. Rebuild containers to apply the new channel:"
+echo "       cd .devcontainer/generacy && docker compose up -d --build"
+echo "    2. Commit the updated configuration files"
+echo ""


### PR DESCRIPTION
## Summary
- Adds `.generacy/cluster.yaml` as the declarative source of truth for cluster configuration (channel, worker count, worker enabled)
- Adds `switch-channel.sh` / `switch-channel.ps1` scripts to switch between `preview` (develop) and `stable` (main) release channels
- Adds `load-cluster-config.sh` startup script that reads `cluster.yaml` and exports env vars, with `.env` overrides taking precedence
- Integrates cluster config loading into both orchestrator and worker entrypoints
- Updates `.env.template` with override documentation and README with full usage docs

All new files are within existing folders (`.generacy/`, `.devcontainer/generacy/scripts/`) — no new directories created.

Closes #2

## Test plan
- [ ] Verify `cluster.yaml` is read correctly by `load-cluster-config.sh` (source the script with a test WORKSPACE_DIR)
- [ ] Verify `.env` values override `cluster.yaml` defaults (set GENERACY_CHANNEL in .env, confirm it takes precedence)
- [ ] Verify `switch-channel.sh preview` updates cluster.yaml, .env.template, and .env
- [ ] Verify `switch-channel.ps1 stable` works equivalently on Windows
- [ ] Verify Docker build succeeds (load-cluster-config.sh is picked up by existing `COPY scripts/` in Dockerfile)
- [ ] Verify orchestrator and worker containers start correctly with cluster.yaml present
- [ ] Verify containers still start correctly when cluster.yaml is absent (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)