### PR TITLE
fix: install @generacy-ai/cluster-relay in orchestrator entrypoint

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -31,6 +31,7 @@ install_packages() {
         "@generacy-ai/generacy@${CHANNEL}" \
         "@generacy-ai/agency@${CHANNEL}" \
         "@generacy-ai/agency-plugin-spec-kit@${CHANNEL}" \
+        "@generacy-ai/cluster-relay@${CHANNEL}" \
         2>>"$SETUP_LOG" || { log "ERROR: npm install failed"; exit 1; }
     # Write marker: channel + installed version of generacy
     local version


### PR DESCRIPTION
## Summary

- Added `@generacy-ai/cluster-relay@${CHANNEL}` to the npm install list in `entrypoint-orchestrator.sh`

## Context

The orchestrator dynamically imports `@generacy-ai/cluster-relay` for cloud connectivity (relay bridge), but the package was not being installed during orchestrator container setup. This caused the relay bridge to silently fail with "Cannot find package '@generacy-ai/cluster-relay'" and the cluster to run in local-only mode even when `GENERACY_API_KEY` and `GENERACY_CLOUD_URL` were configured.

## Test plan

- [ ] Start a fresh orchestrator container with `GENERACY_API_KEY` and `GENERACY_CLOUD_URL` set
- [ ] Verify logs show "Relay bridge configured" (not "Relay bridge not available")

🤖 Generated with [Claude Code](https://claude.com/claude-code)