### PR TITLE
fix: default channel to preview until stable dist-tag exists

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -20,7 +20,7 @@ source /usr/local/bin/load-cluster-config.sh
 
 # Install generacy/agency packages into shared volume
 SHARED_PACKAGES=/shared-packages
-CHANNEL="${GENERACY_CHANNEL:-stable}"
+CHANNEL="${GENERACY_CHANNEL:-preview}"
 MARKER_FILE="${SHARED_PACKAGES}/.installed-version"
 
 install_packages() {

--- a/.generacy/cluster.yaml
+++ b/.generacy/cluster.yaml
@@ -4,7 +4,7 @@
 # The orchestrator reads it on startup; changes take effect on restart
 # (or immediately for settings the orchestrator watches at runtime).
 
-channel: stable          # preview | stable — determines package versions and update source
+channel: preview         # preview | stable — determines package versions and update source
 
 workers:
   count: 3               # number of worker containers


### PR DESCRIPTION
## Problem

`cluster.yaml` ships with `channel: stable`, but the `stable` npm dist-tag does not exist for any `@generacy-ai/*` package (only `latest` and `preview` are present). A fresh `docker compose up` fails immediately because the orchestrator entrypoint runs:

```sh
npm install @generacy-ai/agency@stable   # 404 — dist-tag not found
```

The hard-coded fallback in `entrypoint-orchestrator.sh` (`${GENERACY_CHANNEL:-stable}`) causes the same failure even when `GENERACY_CHANNEL` is unset — for example in a bare `docker run` that skips the `.env` file.

Note: `.env.template` was already corrected to `GENERACY_CHANNEL=preview` in #4, but `cluster.yaml` and the entrypoint were not updated at the same time.

## Fix

| File | Change |
|---|---|
| `.generacy/cluster.yaml` | `channel: stable` → `channel: preview` |
| `.devcontainer/generacy/scripts/entrypoint-orchestrator.sh` | `${GENERACY_CHANNEL:-stable}` → `${GENERACY_CHANNEL:-preview}` |

Both values now agree with `.env.template` and with the only dist-tag that currently resolves cleanly (`preview`, all four packages published together on Apr 7).

## When will `stable` be usable?

Once the `stable` dist-tag is published for all four packages (`@generacy-ai/agency`, `@generacy-ai/agency-plugin-spec-kit`, `@generacy-ai/agency-plugin-humancy`, `@generacy-ai/cluster-relay`), `channel: stable` can be reinstated and this default can be flipped back.

Made with [Cursor](https://cursor.com)