### PR TITLE
feat: #10 dockerfile changes for v1.5 credentials infrastructure

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -46,12 +46,30 @@ RUN mkdir -p /workspaces && chown -R node:node /workspaces
 # (Docker named volumes default to root, causing EACCES for node user)
 RUN mkdir -p /shared-packages && chown node:node /shared-packages
 
-# Credentials architecture: workflow subprocess isolation
-# See tetrad-development docs/credentials-architecture-plan.md decision #4
-# generacy-workflow (uid 1001): agent processes run as this user during workflows
-# credhelper (uid 1002): in-worker credhelper daemon runs as this user
+# Credentials architecture: workflow subprocess isolation (v1.5)
+# See tetrad-development docs/credentials-architecture-plan.md decision #4.
+# These uids exist specifically to enforce uid-boundary isolation between the
+# orchestrator/node user, the agent workflow process, and the credhelper daemon
+# inside a single worker container. Do NOT consolidate them away — the
+# isolation model relies on three distinct uids inside the same container.
+#   generacy-workflow (uid 1001): agent processes run as this user during workflows
+#   credhelper        (uid 1002): in-worker credhelper daemon runs as this user
 RUN useradd --uid 1001 --gid node --no-create-home --shell /bin/bash generacy-workflow \
  && useradd --uid 1002 --gid node --no-create-home --shell /usr/sbin/nologin credhelper
+
+# Credhelper binary + plugins drop here in a future image build.
+# Root-owned, world-readable (0755) so the credhelper uid can read/exec, but
+# only root can modify the contents at runtime.
+RUN mkdir -p /usr/local/lib/generacy-credhelper \
+ && chown root:root /usr/local/lib/generacy-credhelper \
+ && chmod 0755 /usr/local/lib/generacy-credhelper
+
+# Pre-create the credentials state dir so the named-volume mount inherits
+# ownership/mode on first-init. Owned by uid 1000 (node), mode 0700 — see
+# .devcontainer/generacy/docker-compose.yml worker service.
+RUN mkdir -p /var/lib/generacy \
+ && chown node:node /var/lib/generacy \
+ && chmod 0700 /var/lib/generacy
 
 # +============================================================================+
 # |  Customize below: add your project's system dependencies                    |

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -71,7 +71,10 @@ services:
     user: node
     restart: unless-stopped
     tmpfs:
+      # credhelper control socket lives here, owned by the credhelper uid
       - /run/generacy-credhelper:mode=1750,uid=1002,gid=1000
+      # in-cluster control-plane HTTP service socket, owned by the node uid
+      - /run/generacy-control-plane:mode=1750,uid=1000,gid=1000
     stop_grace_period: 30s
     deploy:
       replicas: ${WORKER_COUNT:-3}
@@ -81,6 +84,11 @@ services:
       - ~/.claude.json:/home/node/.claude.json
       # Shared packages volume (read-only: workers consume packages installed by orchestrator)
       - shared-packages:/shared-packages:ro
+      # Credentials state dir: holds the cluster-local sealed store and master.key.
+      # Mode 0700 owned by uid 1000 (node) — set in the image and inherited by
+      # the named volume on first-init. The credhelper uid (1002) writes
+      # master.key inside as 0600 owned by 1002.
+      - generacy-data:/var/lib/generacy
     env_file:
       - path: .env
       - path: .env.local
@@ -136,6 +144,8 @@ volumes:
   shared-packages:
   # npm cache: speeds up repeated package installs on orchestrator restart
   npm-cache:
+  # Credentials state: cluster-local sealed credential store and master.key
+  generacy-data:
 
 networks:
   # Isolated cluster network

--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -8,6 +8,21 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [worker:${AGENT_ID}] $*"
 }
 
+# Credentials architecture (v1.5): block cross-process ptrace before any
+# secret-handling subprocess starts. Yama is a host-global LSM parameter so
+# this is a no-op when the host already has it set (recommended for shared
+# hosts). Soft-fails on unprivileged containers — the entrypoint warns but
+# continues so non-credentialed workflows still run.
+echo 1 > /proc/sys/kernel/yama/ptrace_scope 2>/dev/null \
+    || echo "[warn] Could not set ptrace_scope=1 (requires privileged mode or host-level sysctl)"
+
+# Credentials state dir: 0700 owned by node (uid 1000). Pre-created in the
+# image so the named volume inherits perms on first-init; this block is the
+# idempotent runtime guard for re-runs and pre-existing volumes.
+if [ -d /var/lib/generacy ]; then
+    chmod 0700 /var/lib/generacy 2>/dev/null || true
+fi
+
 log "Starting worker setup..."
 
 # Configure git credentials

--- a/.generacy/README.md
+++ b/.generacy/README.md
@@ -2,6 +2,8 @@
 
 Development cluster setup for AI-powered workflow development with [Generacy](https://github.com/generacy-ai/generacy). Provides an orchestrator, scalable Claude Code workers, Redis, and isolated networking.
 
+> **v1.5 credentials infrastructure.** This image bakes in the uid layout and runtime mounts required by the v1.5 credentials architecture (`generacy-workflow` uid 1001 and `credhelper` uid 1002 alongside `node` uid 1000, tmpfs at `/run/generacy-credhelper` and `/run/generacy-control-plane`, and a `generacy-data` named volume at `/var/lib/generacy`). The credhelper binary, plugins, and bootstrap UI ship in a follow-up image build.
+
 ## Getting Started
 
 ### Option A: New Project (Fork)


### PR DESCRIPTION
Closes #10.

## Summary
- **Dockerfile**: bakes a root-owned `/usr/local/lib/generacy-credhelper/` (0755) for the credhelper binary + plugins from a future image build, pre-creates `/var/lib/generacy` as `node:node` mode 0700 so the named volume inherits perms on first-init, and strengthens the comment block over the uid 1001/1002 `useradd`s explaining that the three-uid layout is load-bearing for v1.5 credential isolation and must not be consolidated.
- **docker-compose.yml** (worker service): adds tmpfs `/run/generacy-control-plane` (mode 1750, uid 1000, gid 1000) alongside the existing `/run/generacy-credhelper`, and mounts a new `generacy-data` named volume at `/var/lib/generacy`.
- **entrypoint-worker.sh**: writes `kernel.yama.ptrace_scope=1` (soft-fails on non-privileged hosts where Yama is set host-side) and idempotently re-asserts `chmod 0700` on `/var/lib/generacy`.
- **.generacy/README.md**: short note that this image is intended for v1.5 credentials work.

DinD-related lines unchanged — cluster-base remains non-DinD per architecture decision #16.

## Test plan
- [ ] `docker compose build` against the updated Dockerfile succeeds.
- [ ] `getent passwd 1001 1002` inside a fresh container returns `generacy-workflow` and `credhelper`.
- [ ] `ls -ld /usr/local/lib/generacy-credhelper` shows `root:root` mode 0755.
- [ ] `ls -ld /var/lib/generacy` on a worker shows `node:node` mode 0700.
- [ ] `findmnt /run/generacy-credhelper` and `findmnt /run/generacy-control-plane` both report `tmpfs` with the expected modes/uids.
- [ ] As `node`, `mkdir /var/lib/generacy/x && chmod 0600 /var/lib/generacy/x/foo` succeeds; the file is owner-only.
- [ ] `cat /proc/sys/kernel/yama/ptrace_scope` reads `1` after the worker entrypoint (or the warning is logged on hosts where the write is blocked).
- [ ] Re-running the entrypoint with the volume already populated leaves perms unchanged (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)