### PR TITLE
feat: #11 publish cluster-base image to GHCR

### DIFF
--- a/.github/workflows/publish-cluster-image.yml
+++ b/.github/workflows/publish-cluster-image.yml
@@ -1,0 +1,94 @@
+name: Publish cluster-base image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (manual test publish; not marked latest)'
+        required: true
+        default: 'dev'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: generacy-ai/cluster-base
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      image: ${{ steps.ver.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="${{ github.event.inputs.tag }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${IMAGE_NAME}:${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer/generacy
+          file: .devcontainer/generacy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.version }}
+            ${{ github.event_name == 'push' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Generacy cluster-base development image — orchestrator + workers, Claude Code, no extra services.
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify credhelper uid (must be 1002)
+        run: |
+          set -euo pipefail
+          IMAGE="${{ needs.build.outputs.image }}"
+          echo "Smoke-testing ${IMAGE}"
+          docker pull "${IMAGE}"
+          OUTPUT=$(docker run --rm "${IMAGE}" id credhelper)
+          echo "${OUTPUT}"
+          echo "${OUTPUT}" | grep -Eq '\buid=1002\b'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# cluster-base
+
+Minimal Generacy cluster image: orchestrator + workers, Claude Code preinstalled, no extra services. Built from [.devcontainer/generacy/Dockerfile](.devcontainer/generacy/Dockerfile) and published to GitHub Container Registry as `ghcr.io/generacy-ai/cluster-base`.
+
+`cluster-base` is one of the cluster image variants consumed by `npx generacy launch`. Architecture context: see [tetrad-development/docs/dev-cluster-architecture.md](https://github.com/generacy-ai/tetrad-development/blob/develop/docs/dev-cluster-architecture.md) — "Cluster image variants".
+
+## Publishing
+
+The image is built and published by [.github/workflows/publish-cluster-image.yml](.github/workflows/publish-cluster-image.yml).
+
+**Triggers:**
+- **Tag push matching `v*`** — releases. Builds, publishes `:<tag>` and `:latest`, then runs the smoke-test job.
+- **`workflow_dispatch`** — manual test publish from the Actions tab. Tags only `:<tag-input>` (does not move `:latest`).
+
+**Build:**
+- Uses Docker Buildx for multi-arch: `linux/amd64` and `linux/arm64`.
+- GitHub Actions cache (`type=gha`) speeds up reruns.
+- Stamps OCI labels: `org.opencontainers.image.source`, `.description`, `.licenses`, `.revision`, `.version`.
+
+**Smoke test:** A separate `smoke-test` job pulls the freshly published image and runs `docker run --rm <image> id credhelper`, asserting `uid=1002`. This guards the v1.5 phase-2 isolation uids (see [Dockerfile](.devcontainer/generacy/Dockerfile) — `generacy-workflow` uid 1001 and `credhelper` uid 1002).
+
+## Tag scheme
+
+| Tag                                              | When applied                  | Floats? |
+| ------------------------------------------------ | ----------------------------- | ------- |
+| `ghcr.io/generacy-ai/cluster-base:vX.Y.Z`        | Tag push `vX.Y.Z`             | No      |
+| `ghcr.io/generacy-ai/cluster-base:latest`        | Tag push (any `v*`)           | Yes     |
+| `ghcr.io/generacy-ai/cluster-base:<dispatch-tag>`| `workflow_dispatch` only      | No      |
+
+Consumers (the `generacy` CLI) pull a pinned semver tag for releases; `latest` is provided for ad-hoc local pulls and is not the recommended production target.
+
+## Cutting a release
+
+1. Merge release-ready changes to `develop` (or your release branch).
+2. Tag and push:
+
+   ```bash
+   git tag v1.5.0
+   git push origin v1.5.0
+   ```
+
+3. Watch the workflow at <https://github.com/generacy-ai/cluster-base/actions/workflows/publish-cluster-image.yml>.
+4. After it succeeds, verify a public pull works (see below).
+
+## Making the package public (one-time, after first publish)
+
+GHCR packages default to **private**, even when published from a public repo. After the first successful publish, an org admin must mark the package public so unauthenticated `docker pull` works:
+
+1. Go to <https://github.com/orgs/generacy-ai/packages/container/cluster-base/settings>.
+2. Scroll to **Danger Zone → Change package visibility**.
+3. Select **Public** and confirm.
+4. Optional but recommended: under **Manage Actions access**, ensure the `cluster-base` repo has `Write` so this workflow can keep publishing.
+
+Verify from any unauthenticated machine:
+
+```bash
+docker logout ghcr.io
+docker pull ghcr.io/generacy-ai/cluster-base:latest
+```
+
+This step is only needed once per package name. Subsequent tags inherit the public visibility.
+
+## Manual test publish
+
+Use this when validating workflow changes without cutting a real release:
+
+1. Open the **Actions** tab → **Publish cluster-base image** → **Run workflow**.
+2. Pick a branch and supply a tag (e.g. `dev-pr42`).
+3. The workflow publishes `ghcr.io/generacy-ai/cluster-base:dev-pr42` and runs the smoke test. `:latest` is **not** moved.


### PR DESCRIPTION
Closes #11.

## Summary
- Adds `.github/workflows/publish-cluster-image.yml` — builds `.devcontainer/generacy/Dockerfile` with Buildx for `linux/amd64` + `linux/arm64`, publishes to `ghcr.io/generacy-ai/cluster-base`, on `v*` tag pushes (and `workflow_dispatch` for manual test publishes).
- Floats `:latest` only on tag pushes; the manual dispatch path tags only the supplied input value.
- Stamps OCI labels (`source`, `description`, `licenses`, `revision`, `version`) and uses GHA cache (`type=gha`) to keep reruns cheap.
- Separate `smoke-test` job pulls the freshly-published image and runs `docker run --rm <image> id credhelper`, asserting `uid=1002` — guards the v1.5 phase-2 isolation uids in the Dockerfile.
- Adds `README.md` documenting the workflow, the one-time GHCR package-visibility step (the package must be marked Public after first publish), and the tag scheme.

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch` with tag `dev-1`) on this branch and confirm both arch builds succeed and the smoke-test job passes.
- [ ] After merge, push a `v1.5.0-rc.1` tag and verify the workflow publishes both `:v1.5.0-rc.1` and `:latest`.
- [ ] Mark `ghcr.io/generacy-ai/cluster-base` Public in the org Packages settings.
- [ ] From an unauthenticated machine: `docker logout ghcr.io && docker pull ghcr.io/generacy-ai/cluster-base:v1.5.0-rc.1` succeeds.
- [ ] Confirm the published image still includes phase-2 Dockerfile additions: `docker run --rm <image> id credhelper` → `uid=1002`, `id generacy-workflow` → `uid=1001`, and `/usr/local/lib/generacy-credhelper` exists with `0755` root:root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)