### PR TITLE
feat: #12 bake code-server into cluster-base image

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -33,6 +33,28 @@ USER root
 # Add Claude to system-wide PATH
 ENV PATH="/home/node/.local/bin:${PATH}"
 
+# Install code-server (pinned). Standalone install prefix puts the binary at
+# /usr/local/bin/code-server, which the in-cluster control-plane lifecycle
+# endpoint expects (CODE_SERVER_BIN default).
+ARG CODE_SERVER_VERSION=4.96.4
+ENV CODE_SERVER_VERSION=${CODE_SERVER_VERSION}
+RUN curl -fsSL https://code-server.dev/install.sh \
+        | sh -s -- --method standalone --prefix /usr/local --version "${CODE_SERVER_VERSION}" \
+ && code-server --version
+
+# Pre-install the curated extension set so first IDE launch is fast.
+# The list lives in a controlled file and is read line-by-line; install runs
+# as the node user since extensions are scoped to that user's data dir.
+COPY code-server-extensions.txt /usr/local/share/code-server-extensions.txt
+USER node
+RUN set -eu; \
+    grep -vE '^\s*(#|$)' /usr/local/share/code-server-extensions.txt \
+        | while IFS= read -r ext; do \
+            [ -z "$ext" ] && continue; \
+            code-server --install-extension "$ext" --force; \
+          done
+USER root
+
 # -- Stage 3: Final image -----------------------------------------------------
 FROM tooling AS final
 

--- a/.devcontainer/generacy/code-server-extensions.txt
+++ b/.devcontainer/generacy/code-server-extensions.txt
@@ -1,0 +1,17 @@
+# Pre-installed code-server extensions, baked into the cluster-base image.
+# One extension id per line. Comments and blank lines are ignored.
+#
+# These reduce first-run overhead on "Open IDE" — every fresh code-server
+# launch starts with these already available.
+#
+# Source registry: code-server defaults to the Open VSX gallery
+# (https://open-vsx.org). Anything pinned here must be available there;
+# Microsoft-marketplace-only extensions cannot be pre-installed this way.
+#
+# TypeScript language support is bundled with code-server itself, so no
+# separate extension is needed for it.
+
+dbaeumer.vscode-eslint
+eamodio.gitlens
+yzhang.markdown-all-in-one
+christian-kohler.path-intellisense

--- a/.github/workflows/publish-cluster-image.yml
+++ b/.github/workflows/publish-cluster-image.yml
@@ -92,3 +92,51 @@ jobs:
           OUTPUT=$(docker run --rm "${IMAGE}" id credhelper)
           echo "${OUTPUT}"
           echo "${OUTPUT}" | grep -Eq '\buid=1002\b'
+
+      - name: Verify code-server is installed at /usr/local/bin/code-server
+        run: |
+          set -euo pipefail
+          IMAGE="${{ needs.build.outputs.image }}"
+          docker run --rm --entrypoint /usr/local/bin/code-server "${IMAGE}" --version
+
+      - name: Verify pre-installed code-server extensions are present
+        run: |
+          set -euo pipefail
+          IMAGE="${{ needs.build.outputs.image }}"
+          INSTALLED=$(docker run --rm --user node --entrypoint code-server "${IMAGE}" --list-extensions)
+          echo "Installed extensions:"
+          echo "${INSTALLED}"
+          for ext in dbaeumer.vscode-eslint eamodio.gitlens yzhang.markdown-all-in-one christian-kohler.path-intellisense; do
+            echo "${INSTALLED}" | grep -Fxq "${ext}" \
+              || { echo "Missing extension: ${ext}"; exit 1; }
+          done
+
+      - name: Verify code-server can boot bound to a Unix socket
+        run: |
+          set -euo pipefail
+          IMAGE="${{ needs.build.outputs.image }}"
+          # Boot code-server in the background bound to a Unix socket and verify
+          # we can hit it with a TCP-over-Unix HTTP request. This is the
+          # end-to-end shape the control-plane lifecycle endpoint produces:
+          # start → socket appears → HTTP responds → stop cleans up.
+          docker run --rm --user node --entrypoint /bin/sh "${IMAGE}" -c '
+            set -eu
+            SOCK=/tmp/code-server.sock
+            code-server --socket "$SOCK" --auth none --disable-telemetry --disable-update-check &
+            CS_PID=$!
+            trap "kill -TERM $CS_PID 2>/dev/null || true" EXIT
+            for i in $(seq 1 50); do
+              [ -S "$SOCK" ] && break
+              sleep 0.2
+            done
+            [ -S "$SOCK" ] || { echo "socket never appeared"; exit 1; }
+            # Hit the socket with an HTTP request (curl supports --unix-socket).
+            curl --silent --output /dev/null --fail --unix-socket "$SOCK" \
+                --max-time 10 http://localhost/healthz \
+              || curl --silent --output /dev/null --unix-socket "$SOCK" \
+                --max-time 10 http://localhost/
+            kill -TERM "$CS_PID"
+            wait "$CS_PID" 2>/dev/null || true
+            [ ! -S "$SOCK" ] || rm -f "$SOCK"
+            echo "code-server boot/stop smoke-test passed"
+          '


### PR DESCRIPTION
Closes #12.

## Summary

- Installs code-server (pinned `4.96.4`) at `/usr/local/bin/code-server` via the official standalone install method (`Dockerfile`).
- Pre-installs a curated set of extensions from `.devcontainer/generacy/code-server-extensions.txt` (ESLint, GitLens, Markdown All-In-One, Path Intellisense). TypeScript LSP is bundled with code-server itself, so no separate extension is needed for it.
- Publish workflow gains three smoke checks: binary present and `--version` works, all curated extensions appear in `--list-extensions`, and code-server boots bound to a Unix socket → responds to HTTP → stops cleanly.

The control-plane lifecycle endpoints (`POST /lifecycle/code-server-start` and `.../code-server-stop`) that drive this binary are implemented in [generacy#510](https://github.com/generacy-ai/generacy/pull/510). The orchestrator npm-installs `@generacy-ai/generacy` at boot, so the runtime gains lifecycle support automatically once that PR ships a release.

## Test plan

- [ ] CI: `Build and push` succeeds for both `linux/amd64` and `linux/arm64`.
- [ ] CI: `smoke-test` job — credhelper uid check still passes.
- [ ] CI: `smoke-test` job — `code-server --version` returns OK.
- [ ] CI: `smoke-test` job — every extension in `code-server-extensions.txt` is present in `--list-extensions`.
- [ ] CI: `smoke-test` job — code-server boots on a Unix socket, accepts an HTTP request, and exits on SIGTERM.
- [ ] After merge: bump a tag and verify the image runs `code-server --version` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)