### PR TITLE
feat: #18 split GENERACY_CLOUD_URL in .env.template into three explicit names

### DIFF
--- a/.devcontainer/generacy/.env.template
+++ b/.devcontainer/generacy/.env.template
@@ -44,7 +44,19 @@ WEBHOOK_SETUP_ENABLED=true
 # Generacy API key — set in .env.local (gitignored), not here
 # Create at: https://staging.generacy.ai/settings#api-keys
 
-# Generacy cloud relay WebSocket URL
+# Generacy HTTP API base URL (REST endpoints)
+# Use api-staging.generacy.ai for staging, api.generacy.ai for production
+GENERACY_API_URL=https://api-staging.generacy.ai
+
+# Generacy app/dashboard URL (browser deep-links)
+# Use staging.generacy.ai for staging, generacy.ai for production
+GENERACY_APP_URL=https://staging.generacy.ai
+
+# Generacy relay WebSocket URL (cluster-relay long-lived connection)
 # Get from your project page: https://staging.generacy.ai/dashboard/projects/YOUR_PROJECT_ID
 # Use api-staging.generacy.ai for staging, api.generacy.ai for production
-GENERACY_CLOUD_URL=wss://api-staging.generacy.ai/relay?projectId=YOUR_PROJECT_ID
+GENERACY_RELAY_URL=wss://api-staging.generacy.ai/relay?projectId=YOUR_PROJECT_ID
+
+# DEPRECATED: Same as GENERACY_RELAY_URL, kept for backward compat for one release.
+# Remove in the next major. New code should read GENERACY_RELAY_URL instead.
+# GENERACY_CLOUD_URL=wss://api-staging.generacy.ai/relay?projectId=YOUR_PROJECT_ID


### PR DESCRIPTION
## Summary

- Phase 3 of generacy-ai/generacy#549 — image-side template split.
- Replaces the single `GENERACY_CLOUD_URL` line in `.devcontainer/generacy/.env.template` with three explicit names (`GENERACY_API_URL`, `GENERACY_APP_URL`, `GENERACY_RELAY_URL`) so the template documents the actual structure.
- Keeps `GENERACY_CLOUD_URL` as a commented-out deprecated fallback for one release, per the issue's migration plan.

Honors decisions from #549 clarify phase: relay URL stays explicit (Q1=A) and `GENERACY_APP_URL` is included in the template even though no current cluster-side code reads it (Q5=C — template is documentation as much as runtime config).

Out of scope per the issue: `setup.sh` and entrypoint scripts. Those hand off to the generacy CLI which is updated separately under #549.

Closes #18

## Test plan

- [ ] Verify the diff matches the issue spec exactly
- [ ] Confirm no schema/smoke tests in this repo validate `.env.template` shape (none currently exist)
- [ ] Manual verification (separate, in generacy repo): a fresh `generacy launch` against the updated cluster-base image produces a working cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)