### PR TITLE
feat: #20 add GENERACY_BOOTSTRAP_MODE=wizard to defer clone for launch flow

### DIFF
--- a/.devcontainer/generacy/.env.template
+++ b/.devcontainer/generacy/.env.template
@@ -36,6 +36,17 @@ SMEE_CHANNEL_URL=
 # Enable label monitoring for GitHub issues
 LABEL_MONITOR_ENABLED=true
 
+# Bootstrap mode — controls whether the cluster expects credentials at boot.
+#   devcontainer (default): user opened the cluster via VS Code Dev Containers
+#       with credentials already in .env / .env.local. Repo is cloned on boot;
+#       missing credentials are a configuration error.
+#   wizard: cluster booted via `npx generacy launch` or cloud deploy. Credentials
+#       arrive post-activation via the bootstrap wizard. Repo clone and
+#       generacy setup steps are deferred until entrypoint-post-activation.sh runs.
+# The launch-CLI scaffolder and the cloud deploy emitter set this to `wizard`;
+# leave unset for the devcontainer flow.
+GENERACY_BOOTSTRAP_MODE=devcontainer
+
 # Enable automatic webhook setup
 WEBHOOK_SETUP_ENABLED=true
 

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ORCHESTRATOR_PORT=${ORCHESTRATOR_PORT:-3100}
       - WORKSPACE_DIR=${WORKSPACE_DIR:-}
       - GENERACY_CHANNEL=${GENERACY_CHANNEL:-stable}
+      - GENERACY_BOOTSTRAP_MODE=${GENERACY_BOOTSTRAP_MODE:-devcontainer}
       - SKIP_PACKAGE_UPDATE=${SKIP_PACKAGE_UPDATE:-false}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${ORCHESTRATOR_PORT:-3100}/health"]
@@ -110,6 +111,7 @@ services:
       - HEALTH_PORT=9001
       - WORKSPACE_DIR=${WORKSPACE_DIR:-}
       - GENERACY_CHANNEL=${GENERACY_CHANNEL:-stable}
+      - GENERACY_BOOTSTRAP_MODE=${GENERACY_BOOTSTRAP_MODE:-devcontainer}
       - SKIP_PACKAGE_UPDATE=${SKIP_PACKAGE_UPDATE:-false}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9001/health"]

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -50,8 +50,12 @@ fi
 # Add shared packages to PATH for this process
 export PATH="${SHARED_PACKAGES}/node_modules/.bin:${PATH}"
 
-# Run generacy setup if CLI is available
-if command -v generacy >/dev/null 2>&1; then
+# Run generacy setup if CLI is available.
+# In wizard mode the workspace isn't cloned yet (credentials arrive post-activation),
+# so workspace/build steps are deferred to entrypoint-post-activation.sh.
+if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" = "wizard" ]; then
+    log "Wizard mode — skipping pre-activation generacy setup; will run after activation"
+elif command -v generacy >/dev/null 2>&1; then
     SETUP_LOG="/tmp/generacy-setup.log"
     log "Running generacy setup..."
 
@@ -74,8 +78,9 @@ if command -v generacy >/dev/null 2>&1; then
     }
 fi
 
-# Light check: warn if speckit is missing (orchestrator can still run)
-if [ -x "/usr/local/bin/setup-speckit.sh" ]; then
+# Light check: warn if speckit is missing (orchestrator can still run).
+# Skip in wizard mode — speckit lives in the not-yet-cloned workspace.
+if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" != "wizard" ] && [ -x "/usr/local/bin/setup-speckit.sh" ]; then
     if ! bash /usr/local/bin/setup-speckit.sh --verify 2>/dev/null; then
         log "WARNING: Speckit commands not available. Workers may fail to process phases."
     fi

--- a/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Post-activation entrypoint — runs once after the bootstrap wizard hands
+# credentials to the cluster (GENERACY_BOOTSTRAP_MODE=wizard flow).
+#
+# Status: skeleton. Not yet wired to a trigger. Invoke manually inside a
+# running orchestrator container after the wizard completes:
+#
+#   docker compose exec orchestrator /usr/local/bin/entrypoint-post-activation.sh
+#
+# The trigger (control-plane endpoint, file watch, or in-process hook fired
+# when activation succeeds) is tracked as a follow-up — see issue #20.
+#
+# Steps:
+#   1. Re-run setup-credentials.sh now that GH_TOKEN / friends are populated.
+#   2. Re-run resolve-workspace.sh to perform the deferred clone.
+#   3. Run `generacy setup workspace` + `generacy setup build` against the
+#      now-populated workspace so workers can pick up speckit.
+#
+# Idempotent — safe to invoke multiple times.
+
+set -e
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [post-activation] $*"
+}
+
+log "Starting post-activation setup..."
+
+# Step 1: configure git/gh credentials from the env vars the wizard delivered
+bash /usr/local/bin/setup-credentials.sh
+
+# Step 2: clone (or pull) the project repo. resolve-workspace.sh exports
+# WORKSPACE_DIR and the wizard-mode branch is a no-op once GENERACY_BOOTSTRAP_MODE
+# is removed/changed; for now force the clone branch by unsetting it locally.
+GENERACY_BOOTSTRAP_MODE="" source /usr/local/bin/resolve-workspace.sh
+
+# Step 3: run the workspace-dependent generacy setup. Mirrors the block in
+# entrypoint-orchestrator.sh that gets skipped during wizard-mode boot.
+SHARED_PACKAGES=/shared-packages
+export PATH="${SHARED_PACKAGES}/node_modules/.bin:${PATH}"
+
+if command -v generacy >/dev/null 2>&1; then
+    SETUP_LOG="/tmp/generacy-setup.log"
+    log "Running generacy setup..."
+
+    generacy setup auth 2>>"$SETUP_LOG" || log "WARNING: 'generacy setup auth' failed (see $SETUP_LOG)"
+
+    CONFIG_PATH="${WORKSPACE_DIR}/.generacy/config.yaml"
+    if [ -f "$CONFIG_PATH" ]; then
+        generacy setup workspace --config "$CONFIG_PATH" --clean 2>>"$SETUP_LOG" || log "WARNING: 'generacy setup workspace' failed (see $SETUP_LOG)"
+    else
+        generacy setup workspace --clean 2>>"$SETUP_LOG" || log "WARNING: 'generacy setup workspace' failed (see $SETUP_LOG)"
+    fi
+
+    generacy setup build 2>>"$SETUP_LOG" || {
+        log "ERROR: 'generacy setup build' failed — attempting speckit recovery (see $SETUP_LOG)"
+        bash /usr/local/bin/setup-speckit.sh 2>>"$SETUP_LOG" || log "ERROR: speckit recovery also failed (see $SETUP_LOG)"
+    }
+else
+    log "WARNING: generacy CLI not on PATH — skipping setup. Restart the orchestrator container to install."
+fi
+
+log "Post-activation setup complete"

--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -57,8 +57,12 @@ fi
 
 log "CLI wrappers created in ${LOCAL_BIN}"
 
-# Run generacy setup if CLI is available
-if command -v generacy >/dev/null 2>&1; then
+# Run generacy setup if CLI is available.
+# In wizard mode the workspace isn't cloned yet (credentials arrive post-activation),
+# so workspace/build steps are deferred to entrypoint-post-activation.sh.
+if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" = "wizard" ]; then
+    log "Wizard mode — skipping pre-activation generacy setup; will run after activation"
+elif command -v generacy >/dev/null 2>&1; then
     SETUP_LOG="/tmp/generacy-setup.log"
     log "Running generacy setup..."
 
@@ -81,8 +85,10 @@ if command -v generacy >/dev/null 2>&1; then
     }
 fi
 
-# Pre-flight: verify speckit readiness
-if [ -x "/usr/local/bin/setup-speckit.sh" ]; then
+# Pre-flight: verify speckit readiness.
+# Skip in wizard mode — speckit lives in the not-yet-cloned workspace; the worker
+# will idle until post-activation completes setup and a restart picks it up.
+if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" != "wizard" ] && [ -x "/usr/local/bin/setup-speckit.sh" ]; then
     if ! bash /usr/local/bin/setup-speckit.sh --verify; then
         log "FATAL: Speckit commands not available. Worker cannot process phases."
         log "FATAL: Check ${SETUP_LOG:-/tmp/generacy-setup.log} for setup errors."

--- a/.devcontainer/generacy/scripts/resolve-workspace.sh
+++ b/.devcontainer/generacy/scripts/resolve-workspace.sh
@@ -47,8 +47,13 @@ fi
 
 # Standalone mode: clone or pull
 if [ -n "${REPO_URL:-}" ] && [ ! -d "${WORKSPACE_DIR}/.git" ]; then
-    log "Cloning project repo: ${REPO_URL} (branch: ${REPO_BRANCH:-main})"
-    git clone --branch "${REPO_BRANCH:-main}" "${REPO_URL}" "${WORKSPACE_DIR}"
+    if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" = "wizard" ]; then
+        log "Wizard mode — deferring repo clone until activation completes (credentials arrive post-wizard)"
+        mkdir -p "${WORKSPACE_DIR}"
+    else
+        log "Cloning project repo: ${REPO_URL} (branch: ${REPO_BRANCH:-main})"
+        git clone --branch "${REPO_BRANCH:-main}" "${REPO_URL}" "${WORKSPACE_DIR}"
+    fi
 elif [ -d "${WORKSPACE_DIR}/.git" ]; then
     log "Project repo already cloned, pulling latest..."
     cd "${WORKSPACE_DIR}"


### PR DESCRIPTION
Closes #20.

## Summary

Adds a `GENERACY_BOOTSTRAP_MODE` env var so the orchestrator/worker entrypoints can boot without credentials when the launch-CLI / cloud-deploy flow is in use. Today the entrypoint always clones the project repo before activation, so the launch flow restart-loops on the failed clone and the bootstrap wizard never gets the device code it's waiting for.

- `devcontainer` (default, preserves existing behavior): clone on boot, run all generacy setup steps. Missing credentials = configuration error, fail loud.
- `wizard`: defer the repo clone in `resolve-workspace.sh`; skip the workspace-dependent generacy setup blocks in `entrypoint-orchestrator.sh` and `entrypoint-worker.sh`. The orchestrator boots through to its device-code emit so the wizard can complete.

A skeleton `entrypoint-post-activation.sh` lands as the documented integration point for the deferred work (re-run `setup-credentials.sh`, `resolve-workspace.sh`, then `generacy setup workspace` + `generacy setup build`). It can be invoked manually today via `docker compose exec orchestrator /usr/local/bin/entrypoint-post-activation.sh`; wiring it to a trigger is the follow-up tracked in issue #20.

Why a dedicated env var rather than reusing `DEVCONTAINER` / `GENERACY_PRE_APPROVED_ACTIVATION_CODE`: the issue thread covers this — both signals conflate cases that need different treatment, and explicit > inferred for something that lives in the cluster's `.env`.

## Files

- `.devcontainer/generacy/scripts/resolve-workspace.sh` — wizard-mode branch defers the clone.
- `.devcontainer/generacy/scripts/entrypoint-orchestrator.sh` — skip pre-activation `generacy setup` and the speckit verify when wizard mode is active.
- `.devcontainer/generacy/scripts/entrypoint-worker.sh` — same gating; in wizard mode the worker no longer FATALs on the missing speckit (it idles until post-activation runs).
- `.devcontainer/generacy/scripts/entrypoint-post-activation.sh` — new skeleton.
- `.devcontainer/generacy/.env.template` — document the new var with both modes.
- `.devcontainer/generacy/docker-compose.yml` — pass `GENERACY_BOOTSTRAP_MODE` through to both services with `devcontainer` default.

## Follow-ups (not in this PR)

Per the issue thread, three companion changes are needed end-to-end:

1. **generacy** — launch scaffolder writes `GENERACY_BOOTSTRAP_MODE=wizard` into the generated `.env`.
2. **generacy-cloud** — DO deploy emitter writes `GENERACY_BOOTSTRAP_MODE=wizard` into the deployed app's env vars.
3. **investigation** — trace the credential-delivery path from wizard → cluster, then either wire `entrypoint-post-activation.sh` into it or file the missing piece.

This PR alone unblocks the orchestrator from boot-looping; (1) and (2) make the wizard appear in the launch/cloud flow; (3) closes the loop so the wizard's "Ready" state actually clones the repo.

## Test plan

- [ ] `bash -n` clean on all four shell scripts (verified locally).
- [ ] Devcontainer flow on a public repo: cluster boots, repo cloned, `generacy setup` runs as before. (Default `GENERACY_BOOTSTRAP_MODE=devcontainer`.)
- [ ] Devcontainer flow on a private repo with `GH_TOKEN` set: still clones, still runs setup.
- [ ] Launch-CLI flow with `GENERACY_BOOTSTRAP_MODE=wizard` and no `GH_TOKEN`: orchestrator does not restart-loop; reaches `generacy orchestrator` exec; emits device code.
- [ ] Manual `docker compose exec orchestrator /usr/local/bin/entrypoint-post-activation.sh` after seeding `GH_TOKEN` clones the repo and runs setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)