### PR TITLE
feat: #22 wire post-activation hook trigger via sentinel-file watcher

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -86,6 +86,18 @@ if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" != "wizard" ] && [ -x "/usr/loca
     fi
 fi
 
+# Wizard mode: arm the post-activation hook.
+# Spawns a background watcher that fires entrypoint-post-activation.sh when
+# the bootstrap-complete sentinel appears. The trigger contract is documented
+# in post-activation-watcher.sh — control-plane (generacy-cloud#532) creates
+# the sentinel after persisting wizard-delivered credentials.
+if [ "${GENERACY_BOOTSTRAP_MODE:-devcontainer}" = "wizard" ]; then
+    POST_ACTIVATION_TRIGGER="${POST_ACTIVATION_TRIGGER:-/tmp/generacy-bootstrap-complete}"
+    log "Arming post-activation watcher (trigger: ${POST_ACTIVATION_TRIGGER})"
+    POST_ACTIVATION_TRIGGER="${POST_ACTIVATION_TRIGGER}" \
+        bash /usr/local/bin/post-activation-watcher.sh &
+fi
+
 # Wait for Redis to be ready
 log "Waiting for Redis at ${REDIS_HOST:-redis}:6379..."
 while ! nc -z "${REDIS_HOST:-redis}" 6379 2>/dev/null; do

--- a/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
@@ -2,13 +2,18 @@
 # Post-activation entrypoint — runs once after the bootstrap wizard hands
 # credentials to the cluster (GENERACY_BOOTSTRAP_MODE=wizard flow).
 #
-# Status: skeleton. Not yet wired to a trigger. Invoke manually inside a
-# running orchestrator container after the wizard completes:
+# Trigger:
+#   entrypoint-orchestrator.sh spawns post-activation-watcher.sh in wizard
+#   mode. The watcher polls a sentinel file (default
+#   /tmp/generacy-bootstrap-complete) and runs this script when the file
+#   appears. Control-plane creates the sentinel as part of its
+#   bootstrap-complete lifecycle handler (generacy-cloud#532).
 #
-#   docker compose exec orchestrator /usr/local/bin/entrypoint-post-activation.sh
+#   For local testing, create the sentinel manually:
+#     docker compose exec orchestrator touch /tmp/generacy-bootstrap-complete
 #
-# The trigger (control-plane endpoint, file watch, or in-process hook fired
-# when activation succeeds) is tracked as a follow-up — see issue #20.
+#   Or invoke this script directly (bypassing the watcher):
+#     docker compose exec orchestrator /usr/local/bin/entrypoint-post-activation.sh
 #
 # Steps:
 #   1. Re-run setup-credentials.sh now that GH_TOKEN / friends are populated.

--- a/.devcontainer/generacy/scripts/post-activation-watcher.sh
+++ b/.devcontainer/generacy/scripts/post-activation-watcher.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Background watcher: waits for a sentinel file, then runs
+# entrypoint-post-activation.sh. Spawned by entrypoint-orchestrator.sh in
+# wizard mode (GENERACY_BOOTSTRAP_MODE=wizard).
+#
+# Trigger contract
+#   Anything that needs to fire the post-activation hook creates the sentinel
+#   file. This is the stable contract this script exposes. Examples:
+#     - control-plane bootstrap-complete handler (generacy-cloud#532) writes
+#       the sentinel after persisting credentials
+#     - manual test:  docker compose exec orchestrator touch <trigger-path>
+#
+# Usage:
+#   post-activation-watcher.sh [trigger-path]
+#
+# Defaults / env overrides:
+#   POST_ACTIVATION_TRIGGER       sentinel path (default /tmp/generacy-bootstrap-complete)
+#   POST_ACTIVATION_POLL_INTERVAL seconds between polls (default 2)
+#   POST_ACTIVATION_LOG           log file for the hook output (default /tmp/post-activation.log)
+#
+# Idempotent: if the sentinel already exists at startup the hook fires
+# immediately; entrypoint-post-activation.sh is itself idempotent so repeated
+# triggers (e.g. after an orchestrator restart) are safe.
+
+set -u
+
+TRIGGER="${1:-${POST_ACTIVATION_TRIGGER:-/tmp/generacy-bootstrap-complete}}"
+POLL_INTERVAL="${POST_ACTIVATION_POLL_INTERVAL:-2}"
+LOG_FILE="${POST_ACTIVATION_LOG:-/tmp/post-activation.log}"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [post-activation-watcher] $*"
+}
+
+log "Watching ${TRIGGER} (poll every ${POLL_INTERVAL}s)..."
+
+while [ ! -e "${TRIGGER}" ]; do
+    sleep "${POLL_INTERVAL}"
+done
+
+log "Trigger detected — running entrypoint-post-activation.sh (output: ${LOG_FILE})"
+
+bash /usr/local/bin/entrypoint-post-activation.sh >>"${LOG_FILE}" 2>&1
+rc=$?
+
+if [ "${rc}" -eq 0 ]; then
+    log "Post-activation completed successfully"
+else
+    log "ERROR: post-activation exited ${rc} — see ${LOG_FILE}"
+fi
+
+exit "${rc}"


### PR DESCRIPTION
## Summary

- Adds `post-activation-watcher.sh`, a polling background watcher that fires `entrypoint-post-activation.sh` when a sentinel file appears.
- `entrypoint-orchestrator.sh` spawns the watcher in wizard mode (`GENERACY_BOOTSTRAP_MODE=wizard`) before `exec`ing the orchestrator.
- Updates `entrypoint-post-activation.sh`'s comment block to document the new trigger contract.

## Design

Closes #22. The issue presents three options (control-plane invocation, file watch, signal handler); this PR implements file-watch as the primary mechanism because it's the most flexible:

- Compatible with the recommended option 1 — control-plane (per generacy-cloud#532) just creates the sentinel as part of its `bootstrap-complete` lifecycle handler.
- Manually testable: `docker compose exec orchestrator touch /tmp/generacy-bootstrap-complete`.
- No `inotify-tools` dependency — polls every 2s, fine for a one-time boot signal.
- Self-contained in cluster-base; doesn't depend on control-plane internals.

Trigger path, poll interval, and log path are all overridable via env vars (`POST_ACTIVATION_TRIGGER`, `POST_ACTIVATION_POLL_INTERVAL`, `POST_ACTIVATION_LOG`).

The watcher runs in the background and is reparented to the orchestrator process after `exec generacy orchestrator`. It exits after firing the hook once, propagating the script's exit code.

## Test plan

- [x] `bash -n` syntax-check on all three scripts
- [x] Smoke test: watcher waits while sentinel absent, fires when created, exit 0 on script success
- [x] Smoke test: watcher exits with non-zero rc when post-activation script fails (initially had a `$?`-after-`if` bug; fixed and re-tested)
- [x] Smoke test: pre-existing sentinel triggers immediately (idempotent restart path)
- [ ] End-to-end with real wizard flow (blocked on generacy-cloud#532 + generacy#558)

## Related

- generacy-ai/cluster-base#22 (this PR)
- generacy-ai/cluster-base#20 — wizard mode that introduced the deferred-setup phase this hook completes
- generacy-ai/generacy-cloud#532 — bootstrap-complete lifecycle action (will write the sentinel)
- generacy-ai/generacy#558 — credential persistence (must land before this hook is useful end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)