### PR TITLE
feat: #26 install Microsoft `code` CLI + vscode-cli auth volume

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -42,6 +42,23 @@ RUN curl -fsSL https://code-server.dev/install.sh \
         | sh -s -- --method standalone --prefix /usr/local --version "${CODE_SERVER_VERSION}" \
  && code-server --version
 
+# Install Microsoft VS Code CLI (`code`) — distinct from code-server above.
+# Needed by control-plane's vscode-tunnel-start lifecycle action to register
+# a VS Code Tunnel for the cluster (so VS Code Desktop deep-links land in
+# the container, not the user's host machine). Pin the version — stdout-format
+# drift from Microsoft would break the device-code regex parsing.
+ARG VSCODE_CLI_VERSION=1.95.3
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) VSCODE_ARCH=cli-linux-x64 ;; \
+         arm64) VSCODE_ARCH=cli-linux-arm64 ;; \
+         *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://update.code.visualstudio.com/${VSCODE_CLI_VERSION}/${VSCODE_ARCH}/stable" -o /tmp/code.tar.gz \
+    && tar -xzf /tmp/code.tar.gz -C /usr/local/bin code \
+    && rm /tmp/code.tar.gz \
+    && code --version
+
 # Pre-install the curated extension set so first IDE launch is fast.
 # The list lives in a controlled file and is read line-by-line; install runs
 # as the node user since extensions are scoped to that user's data dir.

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - shared-packages:/shared-packages
       # npm cache persistence (speeds up repeated installs)
       - npm-cache:/home/node/.npm
+      # VS Code CLI auth state — survives `docker compose down && up` so the
+      # tunnel (started by control-plane's vscode-tunnel-start lifecycle action)
+      # doesn't re-prompt for GitHub device-code auth on every cluster recreate.
+      # Orchestrator only — the tunnel daemon never runs on workers.
+      - vscode-cli:/home/node/.vscode-cli
     env_file:
       - path: .env
       - path: .env.local
@@ -160,6 +165,8 @@ volumes:
   npm-cache:
   # Credentials state: cluster-local sealed credential store and master.key
   generacy-data:
+  # VS Code CLI auth state for the orchestrator's `code tunnel` daemon
+  vscode-cli:
 
 networks:
   # Isolated cluster network


### PR DESCRIPTION
## Summary
- Installs Microsoft's standalone `code` CLI (pinned to 1.95.3) in [`.devcontainer/generacy/Dockerfile`](.devcontainer/generacy/Dockerfile), alongside the existing `code-server` install — distinct tool, needed by control-plane's `vscode-tunnel-start` lifecycle action (shipped in generacy-ai/generacy#585).
- Adds a named `vscode-cli` volume mounted at `/home/node/.vscode-cli` on the orchestrator only — preserves GitHub device-code auth across `docker compose down && up`. Worker excluded; tunnel daemon never runs there.

Closes #26. Companion to generacy-ai/generacy#584 (umbrella).

## Why pin the CLI version?
Per generacy#584 Q5: the lifecycle action regex-parses the device code out of `code tunnel` stdout. An unpinned version risks stdout-format drift breaking parsing silently.

## Test plan
- [ ] After image rebuild: `docker exec <orchestrator> code --version` returns `1.95.3`
- [ ] `docker exec <orchestrator> ls -la /home/node/.vscode-cli` shows the volume is empty initially
- [ ] After completing generacy#584 end-to-end (tunnel started → user enters device code → tunnel registered): `~/.vscode-cli/` contains GitHub auth state
- [ ] After `docker compose down && up`, the tunnel reconnects without re-authentication
- [ ] `docker exec <worker> code --version` works too (binary is in the image), but `~/.vscode-cli` is **not** mounted on workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)