### PR TITLE
feat: #28 source wizard-credentials.env in post-activation

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
@@ -31,6 +31,18 @@ log() {
 
 log "Starting post-activation setup..."
 
+# Source wizard-delivered credentials (written by control-plane's
+# bootstrap-complete handler — see generacy-ai/generacy#589).
+# set -a auto-exports each assigned variable so child processes inherit them.
+WIZARD_CREDS="${WIZARD_CREDS_PATH:-/var/lib/generacy/wizard-credentials.env}"
+if [ -f "$WIZARD_CREDS" ]; then
+    log "Sourcing wizard credentials from $WIZARD_CREDS"
+    set -a
+    # shellcheck disable=SC1090
+    source "$WIZARD_CREDS"
+    set +a
+fi
+
 # Step 1: configure git/gh credentials from the env vars the wizard delivered
 bash /usr/local/bin/setup-credentials.sh
 


### PR DESCRIPTION
## Summary
- Source `/var/lib/generacy/wizard-credentials.env` (written by control-plane on `bootstrap-complete`, per generacy-ai/generacy#589) before `setup-credentials.sh` runs in `entrypoint-post-activation.sh`.
- `set -a` / `set +a` ensures sourced assignments are exported into the `setup-credentials.sh` child process.
- Path is configurable via `WIZARD_CREDS_PATH`; default matches the writer's default.

Closes #28.

## Caveat
As noted in the issue, this alone won't make `git clone` succeed — the writer currently stores installation metadata in `GH_TOKEN`, not a usable installation access token. A companion generacy-cloud change is needed to mint a real token at wizard time. This PR is the cluster-base half of that pair.

## Test plan
- [ ] After image rebuild + cluster start, `docker exec <orchestrator> env` shows `GH_TOKEN` populated post-bootstrap-complete (assuming the env file exists and is non-empty).
- [ ] `/tmp/post-activation.log` no longer contains `WARNING: GH_TOKEN not set`.
- [ ] Running `entrypoint-post-activation.sh` twice remains idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)