### PR TITLE
feat: #30 generate ORCHESTRATOR_INTERNAL_API_KEY in orchestrator entrypoint

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -110,6 +110,13 @@ log "Redis is ready"
 # orchestrator's StatusReporter writes to AND serves the /control-plane/*
 # routes that the cloud relay forwards (e.g. PUT /control-plane/credentials/:id
 # during the bootstrap wizard's "Install GitHub App" step).
+
+# Shared internal-API key so the control-plane process can POST events back
+# to the orchestrator's /internal/relay-events endpoint, which then forwards
+# them through the cluster-relay client. See generacy-ai/generacy#594.
+# Generated per-boot — never persisted, never leaves the container.
+export ORCHESTRATOR_INTERNAL_API_KEY="$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
+
 CONTROL_PLANE_SOCKET_PATH="${CONTROL_PLANE_SOCKET_PATH:-/run/generacy-control-plane/control.sock}"
 export CONTROL_PLANE_SOCKET_PATH
 CONTROL_PLANE_LOG="${CONTROL_PLANE_LOG:-/tmp/control-plane.log}"


### PR DESCRIPTION
## Summary
- Generate a per-boot `ORCHESTRATOR_INTERNAL_API_KEY` (UUID) before spawning the control-plane daemon, so both control-plane and orchestrator inherit the same key via env.
- Enables control-plane → orchestrator IPC on `/internal/relay-events` for cloud relay forwarding (companion to generacy-ai/generacy#594).
- Falls back to `/proc/sys/kernel/random/uuid` if `uuidgen` isn't on the image.

Closes #30.

## Test plan
- [ ] After image rebuild: `docker exec <orchestrator> env` shows `ORCHESTRATOR_INTERNAL_API_KEY` set to a UUID
- [ ] Same value visible in both the orchestrator process env and the control-plane process env (`cat /proc/<pid>/environ | tr '\0' '\n' | grep ORCHESTRATOR_INTERNAL`)
- [ ] Key changes on each container restart (not persistent)

## Related
- generacy-ai/generacy#594 (consuming change — IPC wiring in both processes)
- generacy-ai/generacy#572 (cluster ↔ cloud contract umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)