### PR TITLE
fix: #32 source wizard creds in orchestrator entrypoint + guard git fetch

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -8,6 +8,21 @@ log() {
 
 log "Starting orchestrator setup..."
 
+# Source wizard-delivered credentials persisted by a prior bootstrap
+# (written by control-plane's bootstrap-complete handler — see
+# generacy-ai/generacy#589). On restarts of an already-bootstrapped
+# cluster, GH_TOKEN lives only in this file; without it, setup-credentials
+# warns and the later `git fetch` in resolve-workspace.sh fails auth.
+# Mirrors the same sourcing block in entrypoint-post-activation.sh.
+WIZARD_CREDS="${WIZARD_CREDS_PATH:-/var/lib/generacy/wizard-credentials.env}"
+if [ -f "$WIZARD_CREDS" ]; then
+    log "Sourcing wizard credentials from $WIZARD_CREDS"
+    set -a
+    # shellcheck disable=SC1090
+    source "$WIZARD_CREDS"
+    set +a
+fi
+
 # Configure git credentials
 bash /usr/local/bin/setup-credentials.sh
 

--- a/.devcontainer/generacy/scripts/resolve-workspace.sh
+++ b/.devcontainer/generacy/scripts/resolve-workspace.sh
@@ -57,6 +57,6 @@ if [ -n "${REPO_URL:-}" ] && [ ! -d "${WORKSPACE_DIR}/.git" ]; then
 elif [ -d "${WORKSPACE_DIR}/.git" ]; then
     log "Project repo already cloned, pulling latest..."
     cd "${WORKSPACE_DIR}"
-    git fetch origin
+    git fetch origin 2>/dev/null || true
     git pull --ff-only origin "${REPO_BRANCH:-main}" 2>/dev/null || true
 fi


### PR DESCRIPTION
Fixes #32.

## Summary
- Source `wizard-credentials.env` at the top of `entrypoint-orchestrator.sh` so `GH_TOKEN` (persisted by the wizard) is in env on every restart, mirroring the post-activation sourcing added in #28.
- Guard `git fetch origin` in `resolve-workspace.sh` with `2>/dev/null || true`, matching the existing pattern on the following `git pull` line.

Together these stop the `docker compose down && up` restart loop on an already-bootstrapped cluster: when the persisted token is fresh, fetch succeeds normally; when it's missing or expired (installation tokens expire after ~1h, follow-up in generacy-ai/generacy-cloud#547), the entrypoint continues against the existing workspace instead of `set -e`-exiting and triggering Docker's `restart: unless-stopped`.

## Test plan
- [ ] After both fixes: `docker compose down && up` on a freshly-bootstrapped cluster no longer restart-loops
- [ ] If the env file exists with a fresh `GH_TOKEN`: `git fetch` succeeds, latest commits are pulled
- [ ] If the env file is missing OR token is expired: container starts cleanly, log shows the existing `WARNING: GH_TOKEN not set` message, orchestrator runs against the current workspace state

## Related
- #28 — post-activation sourcing (this PR mirrors that change for the orchestrator entrypoint)
- generacy-ai/generacy#589 — writer side
- generacy-ai/generacy-cloud#547 — token minting / long-running refresh follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)