### PR TITLE
fix: #34 mount vscode-cli volume at /home/node/.vscode/cli

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -110,6 +110,15 @@ RUN mkdir -p /var/lib/generacy \
  && chown node:node /var/lib/generacy \
  && chmod 0700 /var/lib/generacy
 
+# Pre-create the VS Code CLI state dir so the named-volume mount inherits node
+# ownership on first-init. `code` 1.95.3 writes tunnel auth state (token.json,
+# tunnel-stable.lock) to /home/node/.vscode/cli/. Without this pre-create,
+# Docker would create the mount point as root-owned and `code` (running as
+# node) couldn't write to it. See .devcontainer/generacy/docker-compose.yml
+# orchestrator service.
+RUN mkdir -p /home/node/.vscode/cli \
+ && chown -R node:node /home/node/.vscode
+
 # +============================================================================+
 # |  Customize below: add your project's system dependencies                    |
 # |                                                                             |

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -45,7 +45,9 @@ services:
       # tunnel (started by control-plane's vscode-tunnel-start lifecycle action)
       # doesn't re-prompt for GitHub device-code auth on every cluster recreate.
       # Orchestrator only — the tunnel daemon never runs on workers.
-      - vscode-cli:/home/node/.vscode-cli
+      # Path is /home/node/.vscode/cli (where `code` 1.95.3 actually persists
+      # token.json and tunnel-stable.lock), NOT /home/node/.vscode-cli.
+      - vscode-cli-state:/home/node/.vscode/cli
     env_file:
       - path: .env
       - path: .env.local
@@ -165,8 +167,12 @@ volumes:
   npm-cache:
   # Credentials state: cluster-local sealed credential store and master.key
   generacy-data:
-  # VS Code CLI auth state for the orchestrator's `code tunnel` daemon
-  vscode-cli:
+  # VS Code CLI auth state for the orchestrator's `code tunnel` daemon.
+  # Renamed from `vscode-cli` (which mounted at the wrong path) so Docker
+  # provisions a fresh volume at the correct location. Existing clusters will
+  # have a stale `<project>_vscode-cli` volume that can be removed with
+  # `docker volume prune`.
+  vscode-cli-state:
 
 networks:
   # Isolated cluster network


### PR DESCRIPTION
## Summary

- Move the orchestrator's vscode-cli volume mount from `/home/node/.vscode-cli` to `/home/node/.vscode/cli` — the path `code` 1.95.3 actually persists tunnel auth state to.
- Rename the volume `vscode-cli` → `vscode-cli-state` so Docker provisions a fresh volume at the correct path on next `up` (the old volume was empty anyway; users can `docker volume prune` to clean it up).
- Pre-create `/home/node/.vscode/cli` in the Dockerfile owned by `node:node` so the named volume inherits node ownership on first-init (matches the pattern used for `/var/lib/generacy` and `/shared-packages`).

Closes #34.

## Why this matters

#26 introduced the volume mount at the wrong path. The volume was empty and unused, while the real `token.json` lived on the overlay filesystem and got wiped on every `docker compose down && up`. End users had to re-authorize the VS Code Desktop tunnel via GitHub device-code on every cluster recreate.

Verified on a live cluster (per the issue): the mount was at the wrong path, the auth state was on overlay, and the volume contained nothing useful.

## Test plan

- [ ] Rebuild image, recreate cluster: `docker exec <orchestrator> ls -la /home/node/.vscode/cli/` shows it's node-owned and the volume mount is active (write a file, `down/up`, file survives).
- [ ] Complete VS Code Desktop tunnel auth flow → `docker compose down && up` → click "Open in VS Code Desktop" → connects without re-authorization.
- [ ] Existing clusters: confirm stale `<project>_vscode-cli` volume is harmless (empty, root-owned) and can be removed via `docker volume prune` post-upgrade.

## Follow-up

Companion scaffolder change in `generacy` (matching the new path) tracked separately — see the issue's section B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)