### PR TITLE
fix: #36 pre-create /var/lib/generacy-app-config + named volume

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -110,6 +110,18 @@ RUN mkdir -p /var/lib/generacy \
  && chown node:node /var/lib/generacy \
  && chmod 0700 /var/lib/generacy
 
+# Pre-create the app-config state dir so the named-volume mount inherits
+# ownership/mode on first-init. Owned by uid 1000 (node), mode 0750. Holds
+# the materialized non-secret env file and metadata YAML written by the
+# control-plane daemon (which runs as the node uid in the orchestrator
+# container). Without this pre-create, the daemon crashes on init with
+# EACCES because /var/lib is root-owned and the node uid can't create the
+# subdirectory itself. See .devcontainer/generacy/docker-compose.yml
+# orchestrator service.
+RUN mkdir -p /var/lib/generacy-app-config \
+ && chown node:node /var/lib/generacy-app-config \
+ && chmod 0750 /var/lib/generacy-app-config
+
 # Pre-create the VS Code CLI state dir so the named-volume mount inherits node
 # ownership on first-init. `code` 1.95.3 writes tunnel auth state (token.json,
 # tunnel-stable.lock) to /home/node/.vscode/cli/. Without this pre-create,

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -48,6 +48,14 @@ services:
       # Path is /home/node/.vscode/cli (where `code` 1.95.3 actually persists
       # token.json and tunnel-stable.lock), NOT /home/node/.vscode-cli.
       - vscode-cli-state:/home/node/.vscode/cli
+      # App-config state dir: holds the control-plane daemon's materialized
+      # non-secret env file (/var/lib/generacy-app-config/env) and metadata
+      # YAML (values.yaml). Mode 0750 owned by node:node — set in the image
+      # and inherited by the named volume on first-init. Persists across
+      # `docker compose down && up` so app-config values entered via the
+      # bootstrap wizard / Settings panel don't have to be re-entered on
+      # cluster restart.
+      - generacy-app-config-data:/var/lib/generacy-app-config
     env_file:
       - path: .env
       - path: .env.local
@@ -167,6 +175,8 @@ volumes:
   npm-cache:
   # Credentials state: cluster-local sealed credential store and master.key
   generacy-data:
+  # App-config state: control-plane daemon's materialized env file and metadata YAML
+  generacy-app-config-data:
   # VS Code CLI auth state for the orchestrator's `code tunnel` daemon.
   # Renamed from `vscode-cli` (which mounted at the wrong path) so Docker
   # provisions a fresh volume at the correct location. Existing clusters will


### PR DESCRIPTION
## Summary
- Pre-create `/var/lib/generacy-app-config/` as `node:node` mode `0750` in the Dockerfile, parallel to the existing `/var/lib/generacy` block.
- Add a named volume `generacy-app-config-data:/var/lib/generacy-app-config` on the orchestrator service so app-config state persists across `docker compose down && up`.

Closes #36.

The control-plane daemon's `AppConfigEnvStore.init()` was crashing on `fs.mkdir('/var/lib/generacy-app-config', ...)` because the daemon runs as `node` (uid 1000) and `/var/lib/` is root-owned. The crash put clusters in a zombie state — relay connected, control-plane dead, every credential write returning 502. This is currently blocking onboarding on staging.

## Test plan
- [ ] Build the image and verify `/var/lib/generacy-app-config` exists at `node:node 0750`.
- [ ] Boot a cluster from the new image and confirm `/tmp/control-plane.log` does not show the EACCES error.
- [ ] Confirm `/run/generacy-control-plane/control.sock` binds successfully.
- [ ] Run the staging onboarding flow end-to-end (GitHub App step passes, no "Cluster disconnected" error).
- [ ] Verify values entered via the bootstrap wizard survive `docker compose down && up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)