### PR TITLE
fix: #38 mount app-config volume on worker + source env files in entrypoints

### DIFF
--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -28,6 +28,11 @@ services:
     tmpfs:
       # in-cluster control-plane HTTP service socket, owned by the node uid
       - /run/generacy-control-plane:mode=1750,uid=1000,gid=1000
+      # Rendered secret app-config env vars (`secrets.env`). Written by the
+      # control-plane daemon on PUT and re-rendered at boot from the encrypted
+      # ClusterLocalBackend — see generacy-ai/generacy#632. Tmpfs because the
+      # plaintext rendering must never hit disk.
+      - /run/generacy-app-config:mode=1750,uid=1000,gid=1000
     stop_grace_period: 30s
     volumes:
       # Clone mode: persistent volume avoids host mount issues (especially on Windows)
@@ -103,6 +108,14 @@ services:
       - /run/generacy-credhelper:mode=1750,uid=1002,gid=1000
       # in-cluster control-plane HTTP service socket, owned by the node uid
       - /run/generacy-control-plane:mode=1750,uid=1000,gid=1000
+      # Rendered secret app-config env vars (`secrets.env`). Mirrors the
+      # orchestrator tmpfs so worker-side processes have the same surface for
+      # sourcing app-config secrets — keeps dev/testing parity between
+      # orchestrator and worker. Propagation of secret content from the
+      # orchestrator's control-plane to per-worker tmpfs is TBD (see issue #38
+      # Open question / generacy-ai/generacy#632); the tmpfs is in place ahead
+      # of that wiring.
+      - /run/generacy-app-config:mode=1750,uid=1000,gid=1000
     stop_grace_period: 30s
     deploy:
       replicas: ${WORKER_COUNT:-3}
@@ -117,6 +130,11 @@ services:
       # the named volume on first-init. The credhelper uid (1002) writes
       # master.key inside as 0600 owned by 1002.
       - generacy-data:/var/lib/generacy
+      # App-config state dir (read-only on workers): orchestrator's control-plane
+      # daemon writes the materialized non-secret env file
+      # (/var/lib/generacy-app-config/env) and metadata YAML; workers consume.
+      # Read-only because only the orchestrator writes.
+      - generacy-app-config-data:/var/lib/generacy-app-config:ro
     env_file:
       - path: .env
       - path: .env.local

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -23,6 +23,23 @@ if [ -f "$WIZARD_CREDS" ]; then
     set +a
 fi
 
+# Source app-config env vars set via the bootstrap wizard / Settings panel so
+# orchestrator + child processes (control-plane daemon, generacy CLI, spawned
+# workflow runners) inherit user-configured values like LIVEKIT_URL.
+#   - /var/lib/generacy-app-config/env       non-secret, persistent volume
+#   - /run/generacy-app-config/secrets.env   secret, tmpfs, re-rendered at boot
+#     from the encrypted ClusterLocalBackend by the control-plane daemon
+#     (see generacy-ai/generacy#632)
+for app_env in /var/lib/generacy-app-config/env /run/generacy-app-config/secrets.env; do
+    if [ -f "$app_env" ]; then
+        log "Sourcing app-config env from $app_env"
+        set -a
+        # shellcheck disable=SC1090
+        source "$app_env"
+        set +a
+    fi
+done
+
 # Configure git credentials
 bash /usr/local/bin/setup-credentials.sh
 

--- a/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-post-activation.sh
@@ -43,6 +43,18 @@ if [ -f "$WIZARD_CREDS" ]; then
     set +a
 fi
 
+# Source app-config env vars so the post-activation generacy setup sees
+# user-configured values. Mirrors the same block in entrypoint-orchestrator.sh.
+for app_env in /var/lib/generacy-app-config/env /run/generacy-app-config/secrets.env; do
+    if [ -f "$app_env" ]; then
+        log "Sourcing app-config env from $app_env"
+        set -a
+        # shellcheck disable=SC1090
+        source "$app_env"
+        set +a
+    fi
+done
+
 # Step 1: configure git/gh credentials from the env vars the wizard delivered
 bash /usr/local/bin/setup-credentials.sh
 

--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -25,6 +25,25 @@ fi
 
 log "Starting worker setup..."
 
+# Source app-config env vars set via the bootstrap wizard / Settings panel so
+# worker + child processes (agent workflows, MCP servers, user services)
+# inherit user-configured values like LIVEKIT_URL, SERVICE_ANTHROPIC_API_KEY.
+#   - /var/lib/generacy-app-config/env       non-secret, RO mount from named
+#     volume the orchestrator's control-plane writes
+#   - /run/generacy-app-config/secrets.env   secret, per-worker tmpfs. Empty
+#     in v1 — propagation from the orchestrator is TBD (see issue #38 Open
+#     question / generacy-ai/generacy#632); guarded by -f so the no-file case
+#     is a silent no-op.
+for app_env in /var/lib/generacy-app-config/env /run/generacy-app-config/secrets.env; do
+    if [ -f "$app_env" ]; then
+        log "Sourcing app-config env from $app_env"
+        set -a
+        # shellcheck disable=SC1090
+        source "$app_env"
+        set +a
+    fi
+done
+
 # Configure git credentials
 bash /usr/local/bin/setup-credentials.sh
 


### PR DESCRIPTION
## Summary
Closes #38.

- **worker**: read-only mount of `generacy-app-config-data` at `/var/lib/generacy-app-config` so workers can read the materialized non-secret env file the orchestrator's control-plane writes.
- **orchestrator + worker**: add `/run/generacy-app-config` tmpfs (mode 1750, uid 1000) for the rendered `secrets.env`. Mirrored on both services for orchestrator/worker parity during dev/testing — content propagation from orchestrator → worker tmpfs is still TBD and gated on generacy-ai/generacy#632.
- **entrypoint-orchestrator.sh / entrypoint-worker.sh / entrypoint-post-activation.sh**: source both `/var/lib/generacy-app-config/env` and `/run/generacy-app-config/secrets.env` (each guarded by `-f`) using `set -a` so child processes inherit. The orchestrator block lives just before `setup-credentials.sh`, mirroring the existing wizard-credentials sourcing pattern.

Approach A (parity tmpfs on both services) was chosen over the issue's recommended Approach B because the orchestrator is a routine developer-testing surface — keeping the env-sourcing surface identical between orchestrator and worker avoids "works in orchestrator, doesn't in worker" surprises.

## Test plan
- [ ] Build image; `docker exec <worker> ls /var/lib/generacy-app-config/env` returns the file content.
- [ ] After setting `LIVEKIT_URL` via the UI, restart orchestrator; `docker exec <orchestrator> sh -c 'cat /proc/1/environ | tr "\0" "\n" | grep LIVEKIT'` shows the value.
- [ ] Same check on a worker container after restart.
- [ ] Agent workflows spawned from the worker have the env var in their process environment.
- [ ] Once generacy-ai/generacy#632 lands, secret env vars are visible on the orchestrator after restart via `/run/generacy-app-config/secrets.env`.

## Related
- generacy-ai/generacy#632 — renders secrets.env (required for the secret-env path to populate).
- generacy-ai/generacy#622 — original feature; intent was "entrypoint sources the materialized env file" but the cluster-side wiring didn't land.
- generacy-ai/generacy-cloud#583 — UI side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)