### PR TITLE
fix: install @generacy-ai/orchestrator into shared-packages volume

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -61,6 +61,7 @@ install_packages() {
         "@generacy-ai/agency-plugin-spec-kit@${CHANNEL}" \
         "@generacy-ai/cluster-relay@${CHANNEL}" \
         "@generacy-ai/control-plane@${CHANNEL}" \
+        "@generacy-ai/orchestrator@${CHANNEL}" \
         2>>"$SETUP_LOG" || { log "ERROR: npm install failed"; exit 1; }
     # Write marker: channel + installed version of generacy
     local version


### PR DESCRIPTION
## Summary

- The orchestrator container crash-loops on every cluster launch because `@generacy-ai/orchestrator` isn't installed into the `/shared-packages` volume
- generacy-ai/generacy#674 (spec #672) split orchestrator out of the `@generacy-ai/generacy` CLI bundle — the CLI now loads it via dynamic `import()` and reports `ERR_MODULE_NOT_FOUND` as "The orchestrator package is not installed"
- This entrypoint's install list was never updated to add the new package, so dynamic import fails and the container exits, then docker compose restarts it, and so on

## Symptom (observed in `ai-lawfirm-orchestrator-1` on a fresh staging launch)

```
[orchestrator] Installing @generacy-ai packages (channel: preview) into /shared-packages...
[orchestrator] Packages installed (version: 0.0.0-preview-20260520033954)
[orchestrator] Starting orchestrator on port 3100...
The orchestrator package is not installed.
This command requires @generacy-ai/orchestrator, which is not bundled
with the CLI to keep install size small.
[orchestrator] Starting orchestrator setup...    # ← container restart, same thing again
```

`ls /shared-packages/node_modules/@generacy-ai/` confirms: `activation-client`, `cluster-relay`, `config`, `control-plane`, `credhelper`, `generacy`, `workflow-engine`, etc. — but no `orchestrator`.

## Fix

Add `"@generacy-ai/orchestrator@${CHANNEL}"` to the `npm install` line in [.devcontainer/generacy/scripts/entrypoint-orchestrator.sh](../blob/develop/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh#L60-L64), alongside the other `@generacy-ai/*` packages.

## Test plan

- [x] Reproduced manually against `ghcr.io/painworth/ai-lawfirm/generacy:latest` with the updated `npm install` invocation including the new package: install succeeds, all previously-installed `@generacy-ai/*` packages remain present, and `@generacy-ai/orchestrator` is now resolvable for the dynamic import (confirmed via `npm view @generacy-ai/orchestrator@preview dependencies` — all deps are properly rewritten, no `workspace:^` leaks)
- [ ] After merge, sync into cluster-microservices (follow-up PR per cross-repo workflow convention)
- [ ] Rebuild the downstream cluster image (`ghcr.io/painworth/ai-lawfirm/generacy:latest` in this case) and confirm a fresh launch reaches the post-activation watcher without crash-looping

## Related

- generacy-ai/generacy#674 — split that introduced the dynamic import without updating cluster entrypoints
- generacy-ai/generacy#669 — workspace deps rewrite issue (separate concern, but the published orchestrator deps now look correct, which is why this is the only blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)