### PR TITLE
fix: #46 flatten cluster.yaml workers schema to match cloud + orchestrator

### DIFF
--- a/.generacy/cluster.yaml
+++ b/.generacy/cluster.yaml
@@ -5,10 +5,7 @@
 # (or immediately for settings the orchestrator watches at runtime).
 
 channel: stable          # preview | stable — determines package versions and update source
-
-workers:
-  count: 3               # number of worker containers
-  enabled: true          # global worker enable/disable
+workers: 3               # number of worker dev-container replicas
 
 # Future extension points (not yet implemented):
 # resources:


### PR DESCRIPTION
## Summary
- Rewrites `.generacy/cluster.yaml` from the legacy `workers: { count, enabled }` object shape to the canonical flat `workers: <number>` shape
- Drops the `enabled` key (no consumer reads it; it was a decorative toggle in the removed Worker Configuration panel — see generacy-cloud#686)

Closes #46.

## Why it matters
cluster-base is the template the cloud worker merges into every freshly-created project repo. After generacy-cloud#686 and generacy#696 landed, both consumers reject the object shape:
- Orchestrator's `readClusterYaml` requires `typeof parsed?.workers === 'number'` (generacy `relay-bridge.ts:617`)
- Cloud's `getClusterConfig` validates against `z.number().int().min(1)` (generacy-cloud `cluster-config.ts:12`) and throws `ClusterConfigParseError` otherwise

Until this lands, every newly-onboarded project is broken out of the gate.

## Test plan
- [x] YAML parses with `yaml@2.8.2` to `{ channel: 'stable', workers: 3 }` with `typeof workers === 'number'`
- [ ] Spin up a fresh project from the template and confirm the Cluster Config tab loads without `ClusterConfigParseError`
- [ ] Confirm the relay-bridge metadata payload surfaces `workers: 3` from this file
- [ ] Follow-up: file the companion fix in cluster-microservices

## Migration note
Existing onboarded projects already have the object shape merged into their repos and will need a one-time hand-edit of their own `.generacy/cluster.yaml`. The issue floats a potential orchestrator-side rewrite-on-read shim if the support load justifies it — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)