### PR TITLE
fix: #49 cd to WORKSPACE_DIR before exec'ing orchestrator

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -205,6 +205,21 @@ if [ -f "$SECRET_APP_ENV" ]; then
     set +a
 fi
 
+# Ensure the orchestrator process runs with its CWD inside the user's repo.
+# `process.cwd()` is what orchestrator-side file resolution falls back to —
+# /files?path=… (files.ts) and readClusterYaml (relay-bridge.ts) both
+# resolve workspace-relative paths against it. Without this cd, CWD stays
+# at the Dockerfile's WORKDIR (/workspaces) and every workspace-relative
+# read lands one level too high (e.g. /workspaces/.generacy/cluster.yaml
+# instead of /workspaces/<repo>/.generacy/cluster.yaml), which the cloud UI
+# surfaces as "Configuration Not Found".
+if [ -n "${WORKSPACE_DIR:-}" ] && [ -d "$WORKSPACE_DIR" ]; then
+    log "Changing CWD to workspace: $WORKSPACE_DIR"
+    cd "$WORKSPACE_DIR"
+else
+    log "WARNING: WORKSPACE_DIR not set or missing; orchestrator CWD will be $(pwd) — workspace-relative file reads will fail"
+fi
+
 # Start orchestrator as PID 1
 log "Starting orchestrator on port ${ORCHESTRATOR_PORT:-3100}..."
 exec generacy orchestrator \


### PR DESCRIPTION
## Summary
Adds a `cd "$WORKSPACE_DIR"` immediately before the final `exec generacy orchestrator …` so the orchestrator process inherits a CWD inside the user's repo, not `/workspaces` (the Dockerfile's WORKDIR).

Closes #49.

## Why
Without this, `process.cwd()` on the orchestrator is permanently `/workspaces`, and:
- `files.ts` does `resolve(process.cwd(), normalized)` → reads land at `/workspaces/<path>` instead of `/workspaces/<repo>/<path>`
- `relay-bridge.ts` `readClusterYaml` resolves the default relative `clusterYamlPath` (`.generacy/cluster.yaml`) the same way

User-visible symptom: cloud UI's Cluster Config tab shows **"Configuration Not Found"** even when the file is present in the repo.

## Test plan
- [x] `bash -n` passes on the modified entrypoint
- [ ] After deploy, `docker exec <orchestrator> readlink -f /proc/1/cwd` returns the repo path (e.g. `/workspaces/<repo>`), not `/workspaces`
- [ ] Cloud UI's Cluster Config tab loads cluster.yaml content (no "Configuration Not Found")
- [ ] Orchestrator metadata payload reports the `workers` value from cluster.yaml
- [ ] Wizard-mode timing: orchestrator's first `/files` request after post-activation succeeds

## Companion sync
cluster-microservices' entrypoint mirrors this script and will pick this up via the next sync PR (filed alongside this one).

## Related
- generacy/issues/706 — separately tracked refactor of `worker-scaler` to use the Engine API; both fixes are needed for end-to-end worker-scale UX, but they live in different layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)