### PR TITLE
fix: #51 gitignore .generacy/cluster.local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Runtime state written by the orchestrator — never commit.
+# See generacy-ai/generacy#709: orchestrator now writes runtime mutations
+# (e.g. worker replica count after scale) to cluster.local.yaml instead of
+# the git-tracked cluster.yaml.
+.generacy/cluster.local.yaml


### PR DESCRIPTION
## Summary
Adds a root `.gitignore` with `.generacy/cluster.local.yaml` so the runtime-state file the orchestrator writes (introduced by generacy-ai/generacy#709) doesn't appear in `git status` or get accidentally committed.

Closes #51.

## Why root, not `.generacy/.gitignore`?
The issue lists both options as acceptable. Root placement wins on discoverability — surfaces "this template has a .gitignore" to anyone browsing the tree, and a user inspecting `.generacy/` doesn't have to also notice a hidden `.gitignore` to understand what's tracked.

## Test plan
- [x] `git check-ignore -v .generacy/cluster.local.yaml` → matches `.gitignore:5`
- [x] `touch .generacy/cluster.local.yaml && git status` → clean working tree (file not listed as untracked)
- [ ] After this lands, a fresh project bootstrap + worker-scale leaves `git status` clean
- [ ] Subsequent template syncs don't conflict on `cluster.local.yaml` (since it's never committed)

## Companion sync
cluster-microservices needs the same `.gitignore` — sibling sync PR filed alongside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)