### PR TITLE
fix(worker): source wizard-credentials.env so workers get GH_TOKEN (credential parity with orchestrator)

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -25,6 +25,23 @@ fi
 
 log "Starting worker setup..."
 
+# Source wizard-delivered credentials persisted by a prior bootstrap (written
+# by control-plane's bootstrap-complete handler — see generacy-ai/generacy#589).
+# On an already-bootstrapped cluster GH_TOKEN lives only in this file; without
+# it, setup-credentials.sh warns and the clone in resolve-workspace.sh (and the
+# per-job clone in the worker) fails auth with "could not read Username for
+# 'https://github.com'". Mirrors the identical block in entrypoint-orchestrator.sh
+# and entrypoint-post-activation.sh so the worker has the same credentials as the
+# orchestrator (generacy-ai/generacy#632).
+WIZARD_CREDS="${WIZARD_CREDS_PATH:-/var/lib/generacy/wizard-credentials.env}"
+if [ -f "$WIZARD_CREDS" ]; then
+    log "Sourcing wizard credentials from $WIZARD_CREDS"
+    set -a
+    # shellcheck disable=SC1090
+    source "$WIZARD_CREDS"
+    set +a
+fi
+
 # Source app-config env vars set via the bootstrap wizard / Settings panel so
 # worker + child processes (agent workflows, MCP servers, user services)
 # inherit user-configured values like LIVEKIT_URL, SERVICE_ANTHROPIC_API_KEY.


### PR DESCRIPTION
## Problem

On a bootstrapped cluster, **worker containers have no `GH_TOKEN` and no git credentials**, so every job fails at clone time and is dead-lettered. The orchestrator queues issues correctly, but no phase labels ever appear because workers can't check out the repo:

```
gh repo view <owner>/<repo> ... → please run gh auth login / populate GH_TOKEN
git clone https://github.com/<owner>/<repo>.git
fatal: could not read Username for 'https://github.com': No such device or address
```

Each claimed item is retried 3× then moved to `orchestrator:queue:dead-letter`. Observed on a live cloud cluster: 7 enqueued issues, all dead-lettered within seconds, zero processing.

## Root cause

`entrypoint-worker.sh` calls `setup-credentials.sh` but never sources `/var/lib/generacy/wizard-credentials.env`, where `GH_TOKEN` lives on an already-bootstrapped cluster. `setup-credentials.sh` hits its `GH_TOKEN not set → WARNING` guard and returns without configuring git auth or `gh`.

The **orchestrator** entrypoint (and `entrypoint-post-activation.sh`) already source this file — the worker was the only one missing it. The volume (`generacy-data:/var/lib/generacy`) is already mounted into the worker, so the file is present; it just wasn't being read. Net effect: orchestrator and workers had **different credentials**.

## Fix

Add the same `wizard-credentials.env` sourcing block the orchestrator uses, **before** `setup-credentials.sh`, so workers get `GH_TOKEN`/`GH_USERNAME`/`GH_EMAIL` and configure git + `gh` identically to the orchestrator. The block is guarded by `-f`, so the no-file (pre-bootstrap) case is a silent no-op.

## Testing

On a live cluster whose workers were failing every clone, sourcing this file and re-running `setup-credentials.sh` made `git clone` of the private repo succeed (`exit=0`) with no other change. Block is byte-identical to the orchestrator's (already in production) and `bash -n` clean.

## Notes

- Flows downstream to `cluster-microservices` via the usual cluster-base merge.
- `tetrad-development` has a diverged worker entrypoint (uses `bootstrap-worker.sh` + credhelper) and is **not** covered here — needs separate review.
- Related: generacy-ai/generacy#632 (worker secret propagation; `/run/generacy-app-config/secrets.env` is still empty in v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)