### PR TITLE
fix: #61 wire git auth to JIT credential helper; stop static GH_TOKEN seeding

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -165,6 +165,16 @@ RUN mkdir -p /var/lib/generacy-app-config \
  && chown node:node /var/lib/generacy-app-config \
  && chmod 0750 /var/lib/generacy-app-config
 
+# Pre-create the git-token proxy socket dir so the shared named-volume mount
+# inherits node ownership/mode on first-init (generacy-ai/cluster-base#61).
+# Mode 0750 owned node:node: the orchestrator (uid 1000) creates the proxy
+# socket here, and worker-side git processes that share the `node` group
+# (including uid-1001 agent workflows) get group r-x to traverse in and connect
+# to the 0660 socket; other/world is excluded.
+RUN mkdir -p /run/generacy-git-token \
+ && chown node:node /run/generacy-git-token \
+ && chmod 0750 /run/generacy-git-token
+
 # Pre-create the VS Code CLI state dir so the named-volume mount inherits node
 # ownership on first-init. `code` 1.95.3 writes tunnel auth state (token.json,
 # tunnel-stable.lock) to /home/node/.vscode/cli/. Without this pre-create,

--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -61,6 +61,13 @@ services:
       # bootstrap wizard / Settings panel don't have to be re-entered on
       # cluster restart.
       - generacy-app-config-data:/var/lib/generacy-app-config
+      # git-token proxy socket dir (generacy-ai/cluster-base#61). Shared with
+      # the workers so the orchestrator-hosted proxy's Unix socket is reachable
+      # cross-container. Named volume (not tmpfs) because tmpfs is per-container
+      # and a Unix socket must live on a mount both containers can see. Holds
+      # only the socket — no secrets. Mode/ownership inherited from the image's
+      # pre-created node-owned dir on first-init.
+      - git-token-proxy:/run/generacy-git-token
     env_file:
       - path: .env
       - path: .env.local
@@ -135,6 +142,11 @@ services:
       # (/var/lib/generacy-app-config/env) and metadata YAML; workers consume.
       # Read-only because only the orchestrator writes.
       - generacy-app-config-data:/var/lib/generacy-app-config:ro
+      # git-token proxy socket dir (generacy-ai/cluster-base#61). Same shared
+      # volume the orchestrator hosts the proxy socket on; the worker's JIT git
+      # credential helper connects here to mint fresh installation tokens.
+      # NOT read-only: connect() to a Unix socket requires write access.
+      - git-token-proxy:/run/generacy-git-token
     env_file:
       - path: .env
       - path: .env.local
@@ -195,6 +207,9 @@ volumes:
   generacy-data:
   # App-config state: control-plane daemon's materialized env file and metadata YAML
   generacy-app-config-data:
+  # git-token proxy socket: shared so the orchestrator-hosted proxy's Unix
+  # socket is reachable from worker containers (generacy-ai/cluster-base#61).
+  git-token-proxy:
   # VS Code CLI auth state for the orchestrator's `code tunnel` daemon.
   # Renamed from `vscode-cli` (which mounted at the wrong path) so Docker
   # provisions a fresh volume at the correct location. Existing clusters will

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -190,6 +190,34 @@ else
     log "WARNING: control-plane binary not found in ${SHARED_PACKAGES}/node_modules/.bin/ — relay-forwarded /control-plane/* requests will 404"
 fi
 
+# Start the git-token proxy (generacy-ai/cluster-base#61). Workers have no local
+# control-plane, so they cannot reach the JIT git credential helper's control
+# socket directly. This proxy listens on a socket placed on a volume shared with
+# the workers and forwards ONLY POST /git-token to the real control socket —
+# giving workers the "mint a git token" capability without exposing the rest of
+# the control-plane API. It runs only on the orchestrator (the sole holder of
+# the control socket + cluster API key). See git-token-proxy.js.
+GIT_TOKEN_PROXY_SOCKET="${GIT_TOKEN_PROXY_SOCKET:-/run/generacy-git-token/control.sock}"
+export GIT_TOKEN_PROXY_SOCKET
+GIT_TOKEN_PROXY_LOG="${GIT_TOKEN_PROXY_LOG:-/tmp/git-token-proxy.log}"
+if [ -f /usr/local/bin/git-token-proxy.js ]; then
+    log "Starting git-token proxy (socket: ${GIT_TOKEN_PROXY_SOCKET}, log: ${GIT_TOKEN_PROXY_LOG})"
+    GIT_TOKEN_PROXY_SOCKET="${GIT_TOKEN_PROXY_SOCKET}" \
+        CONTROL_PLANE_SOCKET_PATH="${CONTROL_PLANE_SOCKET_PATH}" \
+        node /usr/local/bin/git-token-proxy.js >>"${GIT_TOKEN_PROXY_LOG}" 2>&1 &
+    for _ in $(seq 1 50); do
+        [ -S "${GIT_TOKEN_PROXY_SOCKET}" ] && break
+        sleep 0.2
+    done
+    if [ -S "${GIT_TOKEN_PROXY_SOCKET}" ]; then
+        log "git-token proxy socket ready"
+    else
+        log "WARNING: git-token proxy socket not ready after 10s (see ${GIT_TOKEN_PROXY_LOG}) — worker git auth will fail until it comes up"
+    fi
+else
+    log "WARNING: git-token-proxy.js not found — worker git operations will not be able to fetch JIT tokens"
+fi
+
 # Source app-config secrets — must happen AFTER the control-plane daemon binds
 # its socket because the daemon is what renders /run/generacy-app-config/secrets.env
 # from the encrypted ClusterLocalBackend (see generacy-ai/generacy#632). The

--- a/.devcontainer/generacy/scripts/entrypoint-worker.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-worker.sh
@@ -61,7 +61,15 @@ for app_env in /var/lib/generacy-app-config/env /run/generacy-app-config/secrets
     fi
 done
 
-# Configure git credentials
+# Configure git credentials.
+#
+# Workers have no local control-plane daemon, so the JIT git credential helper
+# (generacy-ai/cluster-base#61) cannot reach the control socket directly. Point
+# it at the orchestrator-hosted git-token proxy, whose socket lives on a volume
+# shared with this container. setup-credentials.sh bakes this path into git
+# config so later git ops (including agent workflows under a different uid)
+# route through it. See git-token-proxy.js and entrypoint-orchestrator.sh.
+export GIT_TOKEN_SOCKET_PATH="${GIT_TOKEN_PROXY_SOCKET:-/run/generacy-git-token/control.sock}"
 bash /usr/local/bin/setup-credentials.sh
 
 # Resolve workspace directory (handles devcontainer detection + clone)

--- a/.devcontainer/generacy/scripts/git-token-proxy.js
+++ b/.devcontainer/generacy/scripts/git-token-proxy.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// git-token-proxy — minimal, single-route forwarder for the JIT git credential
+// helper (generacy-ai/cluster-base#61).
+//
+// Why this exists: the JIT git credential helper (`git-credential-generacy`,
+// shipped in @generacy-ai/control-plane) obtains a fresh GitHub installation
+// token per git op by POSTing to the in-cluster control-plane's Unix socket
+// (generacy-ai/generacy#766). But the control-plane daemon runs ONLY in the
+// orchestrator and binds ONLY a per-container socket — worker containers have
+// their own empty /run/generacy-control-plane tmpfs and cannot reach it.
+//
+// Rather than share the orchestrator's full control socket with workers (which
+// would expose every control-plane route — credential writes, lifecycle
+// actions — to worker containers and to the uid-1001 agent-workflow processes
+// that share the `node` group), this proxy runs on the orchestrator, listens
+// on a socket placed on a volume shared with the workers, and forwards ONLY
+// `POST /git-token` to the real control socket. Workers thus gain exactly one
+// capability — "mint me a git token" — and nothing else.
+//
+// Config (env):
+//   GIT_TOKEN_PROXY_SOCKET   listen socket (shared volume)  default /run/generacy-git-token/control.sock
+//   CONTROL_PLANE_SOCKET_PATH upstream control socket        default /run/generacy-control-plane/control.sock
+
+// CommonJS (require, not import): this is a standalone .js file with no
+// accompanying package.json, so Node loads it as CommonJS by default.
+const http = require('node:http');
+const fs = require('node:fs');
+
+const LISTEN_SOCKET =
+    process.env['GIT_TOKEN_PROXY_SOCKET'] ?? '/run/generacy-git-token/control.sock';
+const UPSTREAM_SOCKET =
+    process.env['CONTROL_PLANE_SOCKET_PATH'] ?? '/run/generacy-control-plane/control.sock';
+
+function log(msg) {
+    const ts = new Date().toISOString();
+    process.stdout.write(`[${ts}] [git-token-proxy] ${msg}\n`);
+}
+
+function sendJson(res, status, body) {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+    });
+    res.end(payload);
+}
+
+const server = http.createServer((req, res) => {
+    // Single allowed route: everything else is refused so this proxy can never
+    // be used as a general control-plane back door.
+    if (req.method !== 'POST' || req.url !== '/git-token') {
+        sendJson(res, 404, {
+            code: 'NOT_FOUND',
+            error: 'git-token-proxy only forwards POST /git-token',
+        });
+        // Drain the request so the socket frees cleanly.
+        req.resume();
+        return;
+    }
+
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('error', () => {
+        // Client went away mid-request — nothing to forward.
+    });
+    req.on('end', () => {
+        const body = Buffer.concat(chunks);
+        const upstream = http.request(
+            {
+                socketPath: UPSTREAM_SOCKET,
+                path: '/git-token',
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    'content-length': body.length,
+                },
+            },
+            (upRes) => {
+                res.writeHead(upRes.statusCode ?? 502, {
+                    'content-type': upRes.headers['content-type'] ?? 'application/json',
+                });
+                upRes.pipe(res);
+            },
+        );
+        upstream.on('error', (err) => {
+            // Upstream (control-plane) unreachable — surface a clear error the
+            // credential helper turns into CONTROL_SOCKET_UNREACHABLE, never a
+            // silent fallback to a stale token.
+            const cause = err.code ?? err.message;
+            sendJson(res, 502, {
+                code: 'CONTROL_SOCKET_UNREACHABLE',
+                error: `control-plane socket at ${UPSTREAM_SOCKET} unreachable (${cause})`,
+            });
+        });
+        upstream.write(body);
+        upstream.end();
+    });
+});
+
+// Remove any stale socket left on the shared volume by a prior boot (the volume
+// persists across container restarts; the socket file does not survive a dead
+// listener).
+try {
+    fs.unlinkSync(LISTEN_SOCKET);
+} catch {
+    // ENOENT is fine.
+}
+
+server.on('error', (err) => {
+    log(`FATAL: listen error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+});
+
+server.listen(LISTEN_SOCKET, () => {
+    // 0660 so the orchestrator (uid 1000) and worker-side git processes that
+    // share the `node` group (incl. uid-1001 agent workflows) can connect,
+    // while other/world cannot.
+    try {
+        fs.chmodSync(LISTEN_SOCKET, 0o660);
+    } catch {
+        // Best-effort.
+    }
+    log(`Listening on ${LISTEN_SOCKET} → forwarding POST /git-token to ${UPSTREAM_SOCKET}`);
+});
+
+function shutdown() {
+    server.close(() => {
+        try {
+            fs.unlinkSync(LISTEN_SOCKET);
+        } catch {
+            // Ignore.
+        }
+        process.exit(0);
+    });
+}
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/.devcontainer/generacy/scripts/setup-credentials.sh
+++ b/.devcontainer/generacy/scripts/setup-credentials.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
-# Configure git credentials from environment variables
-# Called by entrypoint scripts before any git operations
+# Configure git authentication. Called by entrypoint scripts before any git
+# operations.
+#
+# Two regimes, keyed on GENERACY_BOOTSTRAP_MODE:
+#
+#   wizard  (cloud cluster) — durable JIT auth (generacy-ai/cluster-base#61).
+#     git is configured to call the JIT credential helper (`git-credential-
+#     generacy`, shipped in @generacy-ai/control-plane — generacy-ai/generacy
+#     #766) on every operation. The helper fetches a fresh GitHub installation
+#     token from the control-plane on demand (supply side: generacy-ai/
+#     generacy-cloud#817), so the cloud's 1h-capped installation token can
+#     never go stale mid-workflow. NO static token is seeded.
+#
+#   devcontainer (local dev) — static token seeding (unchanged legacy behavior).
+#     Local clusters authenticate with a long-lived developer PAT from .env
+#     (GH_TOKEN); they are not necessarily cloud-activated, so the JIT helper
+#     (which needs the cluster API key written at activation) has no token
+#     source. A developer PAT does not have the 1h installation-token expiry
+#     problem, so static seeding is appropriate here.
+#
+# Socket routing for the JIT helper:
+#   - Orchestrator / post-activation run alongside the control-plane daemon, so
+#     the helper talks to it directly via the default control socket.
+#   - Workers have no local control-plane; the worker entrypoint points them at
+#     the git-token proxy socket (a shared volume) by exporting
+#     GIT_TOKEN_SOCKET_PATH before calling this script. See git-token-proxy.js.
 
 set -e
 
@@ -8,16 +32,9 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [setup-credentials] $*"
 }
 
-if [ -z "${GH_TOKEN:-}" ]; then
-    log "WARNING: GH_TOKEN not set — git operations requiring auth will fail"
-    return 0 2>/dev/null || exit 0
-fi
+MODE="${GENERACY_BOOTSTRAP_MODE:-devcontainer}"
 
-# Configure git credential store with scoped token
-git config --global credential.helper store
-echo "https://${GH_USERNAME:-git}:${GH_TOKEN}@github.com" > ~/.git-credentials
-
-# Configure git identity if provided
+# Configure git identity if provided (sourced from the wizard / .env).
 if [ -n "${GH_EMAIL:-}" ]; then
     git config --global user.email "${GH_EMAIL}"
 fi
@@ -25,7 +42,60 @@ if [ -n "${GH_USERNAME:-}" ]; then
     git config --global user.name "${GH_USERNAME}"
 fi
 
-# Authenticate GitHub CLI
-echo "${GH_TOKEN}" | gh auth login --with-token 2>/dev/null || true
+configure_jit_helper() {
+    # Path to the JIT credential helper, installed into the shared-packages
+    # volume by the orchestrator's package install. Overridable for tests.
+    local helper_js="${GIT_CREDENTIAL_HELPER_JS:-/shared-packages/node_modules/@generacy-ai/control-plane/dist/bin/git-credential-generacy.js}"
 
-log "Git credentials configured"
+    # Control socket the helper POSTs to. Defaults to the in-container control-
+    # plane socket (correct for orchestrator + post-activation); the worker
+    # entrypoint overrides this to the shared git-token proxy socket.
+    local socket_path="${GIT_TOKEN_SOCKET_PATH:-/run/generacy-control-plane/control.sock}"
+
+    # git runs a `credential.helper` whose value starts with `!` as a shell
+    # command, appending the operation (get/store/erase). We inline the socket
+    # path as an env assignment so routing is baked into git config and does
+    # not depend on the (possibly different-uid) environment of whatever process
+    # later runs git — agent workflows on workers run as a separate uid.
+    local helper_cmd="!CONTROL_PLANE_SOCKET_PATH='${socket_path}' node '${helper_js}'"
+
+    # Tear down any legacy static-token wiring so the JIT helper is the ONLY
+    # credential source for github.com (idempotent across re-runs):
+    #   - drop the generic `store` helper a prior version configured,
+    #   - delete the static ~/.git-credentials file it wrote,
+    #   - reset the per-host helper list to just the JIT helper.
+    git config --global --unset-all credential.helper 2>/dev/null || true
+    rm -f "${HOME}/.git-credentials"
+
+    # An empty first entry resets git's per-host helper list, guaranteeing no
+    # inherited helper (e.g. a system-level `store`) is consulted; the JIT
+    # helper is then the sole entry. --replace-all collapses prior-run entries.
+    git config --global --replace-all "credential.https://github.com.helper" "" 2>/dev/null || true
+    git config --global --add "credential.https://github.com.helper" "${helper_cmd}"
+
+    # Note on gists: the helper only answers for host github.com (it exits 0 for
+    # any other host), so gist.github.com cannot be served a token by it. Gist
+    # git auth was never covered by the old static ~/.git-credentials entry
+    # either (keyed to github.com), so this is no regression. If gist auth is
+    # needed later, the helper (generacy#766) must learn gist.github.com first.
+
+    log "Git configured to authenticate via JIT credential helper (socket: ${socket_path})"
+}
+
+configure_static_token() {
+    if [ -z "${GH_TOKEN:-}" ]; then
+        log "WARNING: GH_TOKEN not set (local mode) — git operations requiring auth will fail"
+        return 0
+    fi
+    # Local-dev legacy behavior: store a long-lived developer PAT.
+    git config --global credential.helper store
+    echo "https://${GH_USERNAME:-git}:${GH_TOKEN}@github.com" > "${HOME}/.git-credentials"
+    chmod 600 "${HOME}/.git-credentials" 2>/dev/null || true
+    log "Git credentials configured from static GH_TOKEN (local dev mode)"
+}
+
+if [ "$MODE" = "wizard" ]; then
+    configure_jit_helper
+else
+    configure_static_token
+fi


### PR DESCRIPTION
Closes #61.

## Summary

Configures git on the cluster to authenticate via the **JIT credential helper** (`git-credential-generacy`, shipped in `@generacy-ai/control-plane` — generacy-ai/generacy#766) instead of a static installation token. The helper fetches a fresh GitHub installation token per git op from the control-plane (supply side: generacy-ai/generacy-cloud#817), so the cloud's 1h-capped installation token can no longer go stale mid-workflow. This is the **wiring side** of the durable git-auth fix.

Both dependency PRs have landed (generacy#766, generacy-cloud#817).

## What changed

**`setup-credentials.sh` now branches on `GENERACY_BOOTSTRAP_MODE`:**
- **`wizard` (cloud cluster)** — sets `credential.https://github.com.helper` to the JIT helper and tears down any legacy static wiring (drops the generic `store` helper, deletes `~/.git-credentials`, resets the per-host helper list). No static github.com token remains. `gh auth login --with-token` seeding is dropped; `gh` still reads `GH_TOKEN` from the env for non-git use.
- **`devcontainer` (local dev)** — unchanged: seeds the developer's long-lived PAT from `.env`. A dev PAT has no 1h-expiry problem and a local cluster may not be cloud-activated (no JIT token source), so static seeding is still correct here. This preserves the `.generacy/setup.sh` local flow.

**Worker reachability (the architectural crux):** the control-plane daemon runs **only on the orchestrator** and binds **only** a per-container socket — worker containers have their own empty `/run/generacy-control-plane` tmpfs and cannot reach it. Rather than share the orchestrator's full control socket with workers (which would expose every control-plane route — credential writes, lifecycle actions — to worker containers and to the uid-1001 agent-workflow processes that share the `node` group), this PR adds a **minimal git-token proxy**:

- **`git-token-proxy.js`** — runs on the orchestrator, listens on a socket placed on a volume shared with the workers, and forwards **only** `POST /git-token` to the real control socket. Every other path/method is refused (404), so it can't be used as a general control-plane back door. Workers gain exactly the "mint a git token" capability and nothing else.
- **`entrypoint-orchestrator.sh`** — starts the proxy after the control socket is confirmed up.
- **`entrypoint-worker.sh`** — points the worker's helper at the shared proxy socket via `GIT_TOKEN_SOCKET_PATH` (baked into git config so later git ops, including different-uid agent workflows, route through it).
- **`docker-compose.yml`** — new `git-token-proxy` named volume mounted in both services at `/run/generacy-git-token` (a named volume, not tmpfs, because tmpfs is per-container and a Unix socket must live on a mount both containers can see; holds only the socket — no secrets).
- **`Dockerfile`** — pre-creates `/run/generacy-git-token` (node:node, 0750) so the volume inherits ownership on first-init; the 0660 socket + group-`node` access lets uid-1001 workflows connect.

## Acceptance criteria

- [x] git on the orchestrator and workers (cloud mode) authenticates via the JIT helper; no static github.com token in `~/.git-credentials`.
- [x] Workers reach a fresh-token source over many hours with no manual restart (proxy → control-plane → cloud pull, fresh per op).
- [x] No silent fallback to an expired static token: an unavailable helper/socket surfaces a clear error (`CONTROL_SOCKET_UNREACHABLE` / `CLUSTER_API_KEY_MISSING`), never a stale token.

## Testing

End-to-end validated locally against the real shipped helper (`git-credential-generacy.js`):
- helper → proxy → control socket returns `username=x-access-token` + a fresh `password=<token>`;
- `git credential fill` for `github.com` drives the configured helper and returns the fresh token;
- proxy rejects non-`/git-token` routes (404);
- non-github hosts and `store`/`erase` are no-ops;
- wizard mode tears down pre-existing static `store` + `~/.git-credentials`; idempotent across re-runs;
- local devcontainer mode still seeds the static PAT (mode 600);
- `docker compose config` validates the shared-volume wiring.

## Notes

- Flows downstream to `cluster-microservices` via the usual cluster-base merge (it mirrors the same per-container socket layout).
- Gist auth: the helper only answers for host `github.com` (exits 0 otherwise), so `gist.github.com` is not served a token — but it was never covered by the old static `~/.git-credentials` entry either, so no regression. Serving gist would require the helper (generacy#766) to handle `gist.github.com` first.
- The post-activation `GH_TOKEN`-required guard (#54) is left intact: `GH_TOKEN` is still delivered by the wizard, so it passes, while the actual clone now authenticates via JIT. If `GH_TOKEN` is later dropped from `wizard-credentials.env`, that guard should be revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)