### PR TITLE
fix: #66 JIT gh wrapper + stop VS Code clobbering the git JIT helper …

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -118,7 +118,10 @@ ENV DOCKER_HOST=unix:///var/run/docker-host.sock
 # -- Stage 4: Final image -----------------------------------------------------
 FROM docker-cli AS final
 
-# Copy entrypoint scripts
+# Copy entrypoint scripts. This also installs the JIT `gh` wrapper
+# (scripts/gh, generacy-ai/cluster-base#66) at /usr/local/bin/gh, which precedes
+# /usr/bin/gh on PATH and so shadows the real gh — minting a fresh token per
+# invocation instead of riding the static, expiring GH_TOKEN.
 COPY --chmod=755 scripts/ /usr/local/bin/
 
 # Create workspaces directory with node ownership
@@ -183,6 +186,34 @@ RUN mkdir -p /run/generacy-git-token \
 # orchestrator service.
 RUN mkdir -p /home/node/.vscode/cli \
  && chown -R node:node /home/node/.vscode
+
+# Ship default code-server settings (generacy-ai/cluster-base#66): disable VS
+# Code's built-in git/GitHub credential management so that attaching code-server
+# (or VS Code) to the orchestrator does NOT rewrite ~/.gitconfig back to the
+# gh-CLI credential helper + a static ~/.git-credentials token — which would
+# clobber the JIT git credential helper installed by setup-credentials.sh and
+# then expire ~1h later. code-server reads User settings from
+# <user-data-dir>/User/settings.json; the default user-data-dir is
+# ~/.local/share/code-server (this cluster passes no --user-data-dir override).
+# The dir is pre-created during the extension install above; create+chown is the
+# idempotent guard so the COPY lands node-owned.
+RUN mkdir -p /home/node/.local/share/code-server/User \
+ && chown -R node:node /home/node/.local/share/code-server
+COPY --chown=node:node code-server-settings.json \
+     /home/node/.local/share/code-server/User/settings.json
+
+# Seed the SAME defaults for the Microsoft VS Code Server — the server launched
+# by `code tunnel`, which is what cloud clusters actually run when a user
+# attaches (NOT Coder code-server above). It reads machine-scoped defaults from
+# ~/.vscode-server/data/Machine/settings.json. This is best-effort: it enforces
+# the machine-scoped knobs (git.terminalAuthentication), but the window-scoped
+# github.gitAuthentication can't be pinned from here and the user's synced
+# settings can re-enable it — which is why git-helper-guard.sh re-asserts the
+# JIT helper as the real guarantee (generacy-ai/cluster-base#66).
+RUN mkdir -p /home/node/.vscode-server/data/Machine \
+ && chown -R node:node /home/node/.vscode-server
+COPY --chown=node:node code-server-settings.json \
+     /home/node/.vscode-server/data/Machine/settings.json
 
 # +============================================================================+
 # |  Customize below: add your project's system dependencies                    |

--- a/.devcontainer/generacy/code-server-settings.json
+++ b/.devcontainer/generacy/code-server-settings.json
@@ -1,0 +1,23 @@
+{
+  // Default VS Code settings (generacy-ai/cluster-base#66). Seeded for both
+  // Coder code-server (~/.local/share/code-server/User) and the Microsoft VS
+  // Code Server used by `code tunnel` (~/.vscode-server/data/Machine) — see the
+  // Dockerfile.
+  //
+  // Disable VS Code's built-in git/GitHub credential management. When enabled,
+  // VS Code's git+GitHub integration rewrites ~/.gitconfig back to
+  // credential.helper=store + the gh-CLI helper (`!/usr/bin/gh auth
+  // git-credential`) and caches a static `ghs_` token in ~/.git-credentials —
+  // clobbering the JIT git credential helper that setup-credentials.sh installs
+  // at activation. That static token then expires ~1h later, breaking git auth
+  // for anyone working inside the container.
+  //
+  // Best-effort only: github.gitAuthentication is window-scoped and cannot be
+  // pinned from machine-level defaults (nor against the user's synced settings),
+  // so git-helper-guard.sh re-asserts the JIT helper on drift as the real
+  // guarantee. With these off, VS Code leaves ~/.gitconfig (and the JIT helper)
+  // alone in the common case.
+  "github.gitAuthentication": false,
+  "git.terminalAuthentication": false,
+  "git.useIntegratedAskPass": false
+}

--- a/.devcontainer/generacy/devcontainer.json
+++ b/.devcontainer/generacy/devcontainer.json
@@ -24,7 +24,10 @@
         "anthropics.claude-code"
       ],
       "settings": {
-        "dev.containers.gitCredentialHelperConfigLocation": "none"
+        "dev.containers.gitCredentialHelperConfigLocation": "none",
+        "github.gitAuthentication": false,
+        "git.terminalAuthentication": false,
+        "git.useIntegratedAskPass": false
       }
     }
   },

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -59,6 +59,12 @@ fi
 # Configure git credentials
 bash /usr/local/bin/setup-credentials.sh
 
+# Keep the JIT git credential helper authoritative if VS Code (attached over a
+# `code tunnel`) rewrites ~/.gitconfig back to a static, expiring token
+# (generacy-ai/cluster-base#66). Backgrounded; self-exits outside wizard mode.
+# Runs as node (this entrypoint's user) so it edits /home/node/.gitconfig.
+bash /usr/local/bin/git-helper-guard.sh &
+
 # Resolve workspace directory (handles devcontainer detection + clone)
 source /usr/local/bin/resolve-workspace.sh
 

--- a/.devcontainer/generacy/scripts/gh
+++ b/.devcontainer/generacy/scripts/gh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# JIT `gh` wrapper (generacy-ai/cluster-base#66).
+#
+# Unlike git, the GitHub CLI never consults a credential helper: it reads
+# GH_TOKEN / GITHUB_TOKEN from the environment and uses it exclusively. On a
+# wizard-mode cloud cluster the only GitHub token the container has is a 1-hour
+# `ghs_` installation token baked into the long-lived process env at boot, so
+# any later `gh` invocation — a code-server terminal, an in-container Claude
+# Code agent fixing PR checks — authenticates with a token that expires ~1h
+# after activation and never refreshes, producing `Bad credentials (HTTP 401)`.
+# The automated git path was already migrated to just-in-time tokens
+# (git-credential-generacy, generacy-ai/generacy#766); this shim completes that
+# migration for the interactive `gh` path.
+#
+# Installed ahead of the real gh (/usr/bin/gh) on PATH via the Dockerfile's
+# `COPY scripts/ /usr/local/bin/` (/usr/local/bin precedes /usr/bin). On every
+# invocation it mints a fresh installation token from the control-plane's
+# /git-token endpoint over a Unix socket, then execs the real gh with GH_TOKEN /
+# GITHUB_TOKEN overridden — mirroring the JIT git credential helper so `gh` gets
+# the same never-stale auth.
+#
+# Socket routing matches setup-credentials.sh's JIT git helper exactly:
+#   - orchestrator / post-activation run alongside the control-plane daemon and
+#     talk to it directly via the default control socket (below).
+#   - workers have no local control-plane; entrypoint-worker.sh exports
+#     GIT_TOKEN_SOCKET_PATH pointing at the orchestrator-hosted git-token proxy
+#     socket (a shared volume), and this shim picks it up from the environment.
+#
+# Fail-open: if the socket is missing or the mint fails (e.g. local-dev mode,
+# or control-plane not up yet during early boot), exec the real gh unchanged so
+# it falls back to whatever GH_TOKEN / hosts.yml auth exists — exactly as if
+# this shim were not present.
+
+set -uo pipefail
+
+REAL_GH="/usr/bin/gh"
+SOCKET="${GIT_TOKEN_SOCKET_PATH:-/run/generacy-control-plane/control.sock}"
+
+mint_token() {
+    [ -S "$SOCKET" ] || return 1
+    curl -fsS --max-time 5 --unix-socket "$SOCKET" \
+        -X POST http://localhost/git-token \
+        -H 'Content-Type: application/json' -d '{}' 2>/dev/null \
+        | sed -nE 's/.*"token"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p'
+}
+
+token="$(mint_token || true)"
+
+case "$token" in
+    ghs_*|gho_*|ghp_*|github_pat_*)
+        exec env GH_TOKEN="$token" GITHUB_TOKEN="$token" "$REAL_GH" "$@"
+        ;;
+    *)
+        exec "$REAL_GH" "$@"
+        ;;
+esac

--- a/.devcontainer/generacy/scripts/git-helper-guard.sh
+++ b/.devcontainer/generacy/scripts/git-helper-guard.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# JIT git credential-helper guard (generacy-ai/cluster-base#66).
+#
+# setup-credentials.sh installs a just-in-time git credential helper
+# (git-credential-generacy) in wizard mode. But when a user attaches VS Code /
+# code-server to the container — notably the Microsoft VS Code Server launched
+# by `code tunnel`, which is what cloud clusters actually run — VS Code's
+# git/GitHub integration rewrites ~/.gitconfig back to `credential.helper=store`
+# plus the gh-CLI helper and caches a static `ghs_` token in ~/.git-credentials.
+# That static token expires ~1h later and breaks git auth for anyone working in
+# the container.
+#
+# Shipping VS Code default settings (see Dockerfile) only partially prevents
+# this: the GitHub-extension knob (`github.gitAuthentication`) is window-scoped,
+# so it can't be enforced from machine-level defaults and the user's synced
+# settings can re-enable it. This guard makes the JIT helper authoritative
+# regardless — it polls ~/.gitconfig and re-asserts the JIT helper whenever it
+# drifts. It mirrors the `gh` JIT wrapper's philosophy: don't trust the ambient
+# credential state; re-establish the JIT path on demand.
+#
+# Launched (backgrounded) only by the orchestrator entrypoint — VS Code attaches
+# to the orchestrator, not workers — but it is harmless anywhere: it no-ops when
+# there is no drift and self-exits outside wizard mode.
+
+set -uo pipefail
+
+# Only meaningful in wizard mode (JIT helper). In local-dev / devcontainer mode
+# setup-credentials.sh configures a static long-lived token on purpose; never
+# fight that.
+MODE="${GENERACY_BOOTSTRAP_MODE:-devcontainer}"
+[ "$MODE" = "wizard" ] || exit 0
+
+INTERVAL="${GIT_HELPER_GUARD_INTERVAL:-30}"
+JIT_MARKER="git-credential-generacy"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [git-helper-guard] $*"; }
+
+drifted() {
+    # Drifted if the JIT helper is no longer the github.com credential helper,
+    # OR a generic helper (e.g. `store`) reappeared, OR the static credentials
+    # file was re-created — the hallmarks of the VS Code clobber.
+    git config --global --get-all "credential.https://github.com.helper" 2>/dev/null \
+        | grep -q "$JIT_MARKER" || return 0
+    [ -n "$(git config --global --get-all credential.helper 2>/dev/null)" ] && return 0
+    [ -e "${HOME}/.git-credentials" ] && return 0
+    return 1
+}
+
+log "watching ~/.gitconfig; re-asserting JIT git helper on drift (every ${INTERVAL}s)"
+while true; do
+    if drifted; then
+        log "git credential config drifted (VS Code clobber?) — re-asserting JIT helper"
+        bash /usr/local/bin/setup-credentials.sh >/dev/null 2>&1 || true
+    fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
…(#67)

* fix: #66 JIT gh wrapper + stop VS Code clobbering the git JIT helper

Completes the JIT-token migration for the *interactive* in-container path (#766 / generacy#773 / generacy#777 covered only the automated workflow). Anyone working inside a cluster container — VS Code/code-server attach, or an in-container Claude Code agent — previously lost both `gh` and `git` auth ~1h after activation because the wizard-delivered 1h `ghs_` installation token was baked into the long-lived process env and never refreshed.

gh — ship a JIT `gh` wrapper in the image (scripts/gh → /usr/local/bin/gh, ahead of /usr/bin/gh on PATH). On each invocation it mints a fresh installation token from the control-plane `/git-token` socket and execs the real gh with GH_TOKEN/GITHUB_TOKEN overridden, mirroring git-credential-generacy. Socket routing matches setup-credentials.sh: orchestrator/post-activation use the control socket; workers use the git-token proxy socket via GIT_TOKEN_SOCKET_PATH (exported by entrypoint-worker.sh). Fails open to the real gh when no socket / mint fails, so local-dev and early-boot are unaffected. No cloud change — the /git-token endpoint already exists (generacy#819).

git — ship default code-server settings (code-server-settings.json → ~/.local/share/code-server/User/settings.json) and mirror them into devcontainer.json, disabling VS Code's built-in git/GitHub credential management (github.gitAuthentication, git.terminalAuthentication, git.useIntegratedAskPass). This stops code-server/VS Code from rewriting ~/.gitconfig back to the gh-CLI helper + a static ~/.git-credentials token, which clobbered the JIT git credential helper and then expired ~1h later.



* fix: re-assert JIT git helper against VS Code tunnel clobbering (#66)

The VS Code settings shipped in this PR target Coder code-server (~/.local/share/code-server/User) and devcontainer.json, but cloud clusters are attached via the Microsoft VS Code Server (`code tunnel`), which reads ~/.vscode-server/data/Machine/settings.json and ignores devcontainer.json customizations — so the clobber-prevention never reached the server that actually causes it.

- Add git-helper-guard.sh: a backgrounded, wizard-mode-only watcher that re-asserts the JIT git credential helper whenever ~/.gitconfig drifts (store/gh-helper/~/.git-credentials reappear). This is the real guarantee — it does not depend on VS Code setting scopes — and mirrors the gh JIT wrapper's "re-establish the JIT path on demand" approach. Launched from the orchestrator entrypoint (where VS Code attaches).
- Seed the same defaults at ~/.vscode-server/data/Machine/settings.json so the tunnel server honors the machine-scoped knobs (best-effort; the window-scoped github.gitAuthentication can't be pinned there).
- Clarify code-server-settings.json header to reflect both servers and that the guard is the authoritative fix.



---------