### PR TITLE
feat: #69 install claude-plugin-cockpit during cluster setup (channel-aware)

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -89,6 +89,22 @@ install_packages() {
         "@generacy-ai/control-plane@${CHANNEL}" \
         "@generacy-ai/orchestrator@${CHANNEL}" \
         2>>"$SETUP_LOG" || { log "ERROR: npm install failed"; exit 1; }
+
+    # Cockpit Claude Code plugin (generacy-ai/cluster-base#69). Installed as a
+    # separate, best-effort step so it can NOT brick cluster boot: the package
+    # may be absent from a given channel (e.g. before it is published to
+    # ${CHANNEL}), and a missing tag would fail the whole install above. It lands
+    # in the shared-packages volume where `generacy setup build` (G-S5) resolves
+    # it (Tier 2) and copies commands/*.md into ~/.claude/commands/cockpit/,
+    # making /cockpit:* available with no manual marketplace/npm steps.
+    log "Installing @generacy-ai/claude-plugin-cockpit@${CHANNEL} (best-effort) into ${SHARED_PACKAGES}..."
+    npm install \
+        --prefix "${SHARED_PACKAGES}" \
+        --no-save \
+        "@generacy-ai/claude-plugin-cockpit@${CHANNEL}" \
+        2>>"$SETUP_LOG" \
+        || log "WARNING: cockpit plugin install failed (channel: ${CHANNEL}) — /cockpit:* may be unavailable (see $SETUP_LOG)"
+
     # Write marker: channel + installed version of generacy
     local version
     version=$(node -e "console.log(require('${SHARED_PACKAGES}/node_modules/@generacy-ai/generacy/package.json').version)" 2>/dev/null || echo "unknown")

--- a/.devcontainer/generacy/scripts/setup-speckit.sh
+++ b/.devcontainer/generacy/scripts/setup-speckit.sh
@@ -6,6 +6,12 @@
 
 SETUP_LOG="${SETUP_LOG:-/tmp/generacy-setup.log}"
 
+# Release channel for npm installs. GENERACY_CHANNEL is exported by
+# load-cluster-config.sh in the entrypoints that invoke this script, so a
+# preview cluster recovers the preview-channel packages. Mirrors
+# entrypoint-orchestrator.sh's CHANNEL derivation.
+CHANNEL="${GENERACY_CHANNEL:-stable}"
+
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] [setup-speckit] $*"
 }
@@ -43,12 +49,22 @@ if [ "$1" = "--verify" ]; then
 fi
 
 # Full setup mode — recover speckit via npm (no git clone needed)
-log "Installing @generacy-ai/agency-plugin-spec-kit from npm..."
-npm install -g @generacy-ai/agency-plugin-spec-kit 2>>"$SETUP_LOG" || {
-    log "ERROR: npm install -g @generacy-ai/agency-plugin-spec-kit failed"
+log "Installing @generacy-ai/agency-plugin-spec-kit@${CHANNEL} from npm..."
+npm install -g "@generacy-ai/agency-plugin-spec-kit@${CHANNEL}" 2>>"$SETUP_LOG" || {
+    log "ERROR: npm install -g @generacy-ai/agency-plugin-spec-kit@${CHANNEL} failed"
     exit 1
 }
 log "agency-plugin-spec-kit installed"
+
+# Cockpit Claude Code plugin (generacy-ai/cluster-base#69). Best-effort: unlike
+# speckit this is an orchestrator-only convenience and NOT required for workers
+# to process phases, so a failure here (e.g. the package not yet published to
+# ${CHANNEL}) must not fail speckit recovery. The `generacy setup build` re-run
+# below wires /cockpit:* from it (G-S5) exactly as it does for speckit.
+log "Installing @generacy-ai/claude-plugin-cockpit@${CHANNEL} from npm (best-effort)..."
+npm install -g "@generacy-ai/claude-plugin-cockpit@${CHANNEL}" 2>>"$SETUP_LOG" \
+    && log "claude-plugin-cockpit installed" \
+    || log "WARNING: npm install -g @generacy-ai/claude-plugin-cockpit@${CHANNEL} failed — /cockpit:* may be unavailable (see $SETUP_LOG)"
 
 # Re-run generacy setup build to trigger Phase 4 (copies command files)
 if command -v generacy >/dev/null 2>&1; then


### PR DESCRIPTION
Closes generacy-ai/cluster-base#69 (Epic Cockpit · S7 · C-S1).

## What

Install `@generacy-ai/claude-plugin-cockpit@${CHANNEL}` during cluster setup so `/cockpit:*` is available in a fresh Claude Code session in the orchestrator dev container with **zero** manual marketplace/npm steps. Mirrors how spec-kit is already installed.

## Changes

- **`entrypoint-orchestrator.sh` → `install_packages()`** — the happy-path install. Adds the cockpit plugin to the shared-packages volume (`/shared-packages/node_modules/...`). That is Tier 2 of `generacy setup build`'s cockpit resolver (G-S5, [generacy#816](https://github.com/generacy-ai/generacy/issues/816)), which copies `commands/*.md` into `~/.claude/commands/cockpit/`. `install_packages()` runs **before** the wizard-mode branch, so both devcontainer and wizard/preview clusters get it. Channel-aware via the existing `CHANNEL` (`${GENERACY_CHANNEL:-stable}`), matching `entrypoint-orchestrator.sh:85`.
- **`setup-speckit.sh` (build-failure recovery path)** — mirrors the cockpit install as a global `npm install -g`, and (per the issue's optional suggestion) aligns the **spec-kit** recovery install to `${CHANNEL}` too — it was previously untagged/`latest`, so a preview cluster could recover a stable spec-kit. `GENERACY_CHANNEL` is exported by `load-cluster-config.sh` in every entrypoint that invokes this script, so the channel is inherited.

## Safety: best-effort, non-fatal

Both cockpit installs are deliberately **non-fatal**:
- The package may be absent from a given channel, and a missing tag would otherwise fail the whole `npm install` and brick boot. The cockpit install is a **separate** step guarded with `|| log WARNING`.
- Cockpit is an orchestrator-only convenience; it is **not** required for workers. `verify_speckit` is intentionally left speckit-only so a missing cockpit never trips the worker's fatal `setup-speckit.sh --verify` gate.

Verified the degradation path: with the package currently unpublished (404), the install block returns exit 0 and boot proceeds to the marker write.

## Dependencies / follow-up

- **A-S2 (`@generacy-ai/claude-plugin-cockpit` published to npm)** is **not yet satisfied**: the publish PR [agency#375](https://github.com/generacy-ai/agency/pull/375) was closed unmerged and `npm view @generacy-ai/claude-plugin-cockpit` currently 404s. Until it is published to the `preview` tag, this change installs nothing (gracefully) and `/cockpit:*` won't appear. The full acceptance check ("freshly deployed preview cluster has `/cockpit:*` working") can only be verified once A-S2 lands.
- **Image republish**: cluster-base no longer publishes its own image — the build/publish workflow lives in [generacy-ai/generacy](https://github.com/generacy-ai/generacy) and pushes channel-aware tags (`develop` → `ghcr.io/generacy-ai/cluster-base:preview`). Merging this to `develop` + running that workflow republishes the preview image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)