### PR TITLE
fix: #71 seed shared-packages manifest so cockpit install can't prune the generacy bin

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -78,6 +78,35 @@ CHANNEL="${GENERACY_CHANNEL:-stable}"
 MARKER_FILE="${SHARED_PACKAGES}/.installed-version"
 
 install_packages() {
+    # Seed a manifest in the shared volume declaring the core packages as
+    # dependencies. /shared-packages has no package.json of its own, so without
+    # this every already-installed package is *extraneous* to npm. The separate
+    # best-effort cockpit install below then reconciles the tree on its own
+    # terms and prunes everything it doesn't depend on — including the core
+    # packages' bin symlinks (notably .bin/generacy). That leaves the final
+    # `exec generacy orchestrator` failing with "generacy: not found" and the
+    # orchestrator in a crash loop, but only on channels where the cockpit
+    # package actually publishes (e.g. preview) so the second install succeeds
+    # and reconciles. Declaring the core packages here keeps them in npm's ideal
+    # tree so the cockpit install can no longer prune them
+    # (generacy-ai/cluster-base#71). Keep this list in sync with the install
+    # command below.
+    log "Seeding ${SHARED_PACKAGES}/package.json to protect core packages from prune..."
+    cat > "${SHARED_PACKAGES}/package.json" <<'EOF'
+{
+  "name": "generacy-shared-packages",
+  "private": true,
+  "dependencies": {
+    "@generacy-ai/generacy": "*",
+    "@generacy-ai/agency": "*",
+    "@generacy-ai/agency-plugin-spec-kit": "*",
+    "@generacy-ai/cluster-relay": "*",
+    "@generacy-ai/control-plane": "*",
+    "@generacy-ai/orchestrator": "*"
+  }
+}
+EOF
+
     log "Installing @generacy-ai packages (channel: ${CHANNEL}) into ${SHARED_PACKAGES}..."
     npm install \
         --prefix "${SHARED_PACKAGES}" \


### PR DESCRIPTION
Fixes #71.

## Problem

Fresh `preview`-channel local clusters crash-loop the orchestrator container. `install_packages()` in `entrypoint-orchestrator.sh` runs two `npm install --prefix /shared-packages --no-save` commands into a directory with **no `package.json`**:

1. the core packages (`@generacy-ai/generacy` + 5 others) — provides the `generacy` bin
2. `@generacy-ai/claude-plugin-cockpit` (best-effort, added in #69 / #70)

With no manifest, npm treats the first batch as **extraneous** and the second (cockpit) install reconciles the tree, pruning the core packages' bin symlinks — including `.bin/generacy`. The final `exec generacy orchestrator` then fails with `generacy: not found` → container exits → restart loop.

It only bites on channels where cockpit is actually published (e.g. `preview`); on `stable` the second install no-ops as a best-effort warning and never reconciles, so the bins survive.

## Fix

Seed a `package.json` into `/shared-packages` declaring the six core packages as dependencies before installing. They stay in npm's ideal tree, so the best-effort cockpit install can no longer prune them. Cockpit remains a separate, non-bricking step — the property #69 intended is preserved.

## Verification

Applied the equivalent manifest to the affected live cluster's `/shared-packages` volume: the next install cycle repopulated `.bin/generacy`, `exec generacy orchestrator` succeeded, and the container went `healthy` and stable (advanced to the normal activation-wizard state). `bash -n` passes on the edited script. Confirmed `setup-speckit.sh` is unaffected — it uses additive `npm install -g`, not a shared `--prefix` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)