### PR TITLE
fix: #73 put generacy/agency CLIs on PATH for interactive & tunnel shells

### DIFF
--- a/.devcontainer/generacy/Dockerfile
+++ b/.devcontainer/generacy/Dockerfile
@@ -131,6 +131,22 @@ RUN mkdir -p /workspaces && chown -R node:node /workspaces
 # (Docker named volumes default to root, causing EACCES for node user)
 RUN mkdir -p /shared-packages && chown node:node /shared-packages
 
+# Put the user-facing CLIs on PATH for every shell type.
+# The entrypoint's npm install lands the CLI bins in the shared-packages volume
+# (/shared-packages/node_modules/.bin) and exports that dir onto PATH for the
+# entrypoint process ONLY — daemons it spawns inherit it, but interactive shells
+# and the VS Code tunnel session a developer actually attaches to do NOT. That
+# left `command -v generacy` failing (binary present, just not on PATH), which
+# breaks every /cockpit:* preflight and contradicts the zero-step goal
+# (generacy-ai/cluster-base#73, #69). Symlinking into /usr/local/bin at build
+# time (as root — the entrypoint runs as node and cannot write here) works
+# regardless of profile loading, unlike a ~/.bashrc/profile.d export — the same
+# reason code-server, code, and the gh wrapper live here. The links dangle only
+# during the brief boot window before the entrypoint populates the volume; once
+# the install runs they resolve through the mounted volume for all shells.
+RUN ln -sf /shared-packages/node_modules/.bin/generacy /usr/local/bin/generacy \
+ && ln -sf /shared-packages/node_modules/.bin/agency /usr/local/bin/agency
+
 # Credentials architecture: workflow subprocess isolation (v1.5)
 # See tetrad-development docs/credentials-architecture-plan.md decision #4.
 # These uids exist specifically to enforce uid-boundary isolation between the


### PR DESCRIPTION
Fixes #73.

## Problem

On a fresh cluster, `command -v generacy` fails in the dev-container session a developer actually uses (interactive shell / VS Code tunnel terminal), even though the binary exists at `/shared-packages/node_modules/.bin/generacy`. This breaks **every `/cockpit:*` command at preflight** (`MISSING_BINARY`) and contradicts the zero-step goal (#69).

Root cause: the orchestrator entrypoint installs the CLI bins into the shared-packages volume and puts `.bin` on PATH **only for the entrypoint process** (`entrypoint-orchestrator.sh:151-152`). Daemons it spawns inherit that PATH; interactive shells and the tunnel session do **not**.

## Fix

Symlink the user-facing CLIs (`generacy`, `agency`) into `/usr/local/bin` **at build time in the Dockerfile**:

```dockerfile
RUN ln -sf /shared-packages/node_modules/.bin/generacy /usr/local/bin/generacy \
 && ln -sf /shared-packages/node_modules/.bin/agency /usr/local/bin/agency
```

`/usr/local/bin` is on PATH for **every** shell type regardless of profile loading — the same reason `code-server`, `code`, and the `gh` wrapper already live there. This makes permanent the manual symlink repair validated on `sniplink-orchestrator-1`.

### Why build-time (Dockerfile), not runtime (entrypoint)

The issue suggested `ln -sf ...` after the npm install in the entrypoint, but the entrypoint runs as **`node`** (`user: node` in compose) and `/usr/local/bin` is root-owned — a runtime `ln` there would `EACCES`. Creating the symlinks at build time (as root) is the clean, permission-safe way, and matches the repo's established pattern for PATH-universal binaries. The target path (`/shared-packages/node_modules/.bin/…`) is deterministic, so the links resolve through the mounted volume once the entrypoint's install populates it. They dangle only during the brief first-boot window before that install completes — well before any developer attaches to run `/cockpit:*`; on any restart/recreate with a populated volume they resolve immediately.

`agency` is included because the worker entrypoint already treats it as a user-invocable CLI (`for cli in generacy agency`). The `git-credential-generacy` helper is **not** affected — git config invokes it via an absolute path, not PATH.

## Verification

Simulated the exact npm symlink chain (`/usr/local/bin/generacy` → `.bin/generacy` → `../@generacy-ai/generacy/bin/generacy.js`): before the volume is populated the link dangles; after, `command -v generacy` succeeds, resolves through the full chain, and executes via PATH from a shell that never sourced any profile.

## Rollout

Dockerfile change — takes effect once `ghcr.io/generacy-ai/cluster-base:preview` is rebuilt from `develop` (per the channel table in the README) and a cluster pulls the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)