### PR TITLE
feat: #75 register cockpit MCP server user-scope on the orchestrator + GENERACY_CLUSTER_ROLE compose parity

### DIFF
--- a/.devcontainer/generacy/docker-compose.yml
+++ b/.devcontainer/generacy/docker-compose.yml
@@ -82,6 +82,11 @@ services:
       - GENERACY_CHANNEL=${GENERACY_CHANNEL:-stable}
       - GENERACY_BOOTSTRAP_MODE=${GENERACY_BOOTSTRAP_MODE:-devcontainer}
       - SKIP_PACKAGE_UPDATE=${SKIP_PACKAGE_UPDATE:-false}
+      # Cluster role (generacy-ai/cluster-base#75, mirrors the generacy scaffolder
+      # compose — generacy#917 Q2-A). Gates role-aware behavior like the
+      # `generacy cockpit mcp` worker-refusal backstop. Must stay in parity with
+      # the scaffolder-generated compose (they have silently diverged before).
+      - GENERACY_CLUSTER_ROLE=orchestrator
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${ORCHESTRATOR_PORT:-3100}/health"]
       interval: 30s
@@ -161,6 +166,11 @@ services:
       - GENERACY_CHANNEL=${GENERACY_CHANNEL:-stable}
       - GENERACY_BOOTSTRAP_MODE=${GENERACY_BOOTSTRAP_MODE:-devcontainer}
       - SKIP_PACKAGE_UPDATE=${SKIP_PACKAGE_UPDATE:-false}
+      # Cluster role (generacy-ai/cluster-base#75, mirrors the generacy scaffolder
+      # compose — generacy#917 Q2-A). Drives the defense-in-depth refusal in
+      # `generacy cockpit mcp` if it is ever invoked on a worker; the primary
+      # control is that entrypoint-worker.sh registers no MCP server at all.
+      - GENERACY_CLUSTER_ROLE=worker
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9001/health"]
       interval: 30s

--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -151,6 +151,97 @@ fi
 # Add shared packages to PATH for this process
 export PATH="${SHARED_PACKAGES}/node_modules/.bin:${PATH}"
 
+# Register the cockpit MCP server for the orchestrator's Claude sessions at
+# **user scope** (generacy-ai/cluster-base#75 — companion to generacy#917
+# FR-010, whose MCP server shipped but is unreachable until something registers
+# it). Contract source of truth:
+# specs/917-improvement-spec-from-cockpit/contracts/entrypoint-registration.md.
+#
+# Runs HERE — after the shared-packages install + PATH export above — so the
+# `generacy` binary the entry launches exists (it's symlinked into
+# /usr/local/bin for every shell type, see #73, and resolves through the volume
+# this install just populated). Writes ~/.claude.json's mcpServers.cockpit key
+# directly (the documented user-scope location — equivalent to
+# `claude mcp add --scope user cockpit -- generacy cockpit mcp`), which is
+# deterministic and doesn't depend on the `claude` CLI's add/overwrite exit
+# semantics.
+#
+# The WORKER entrypoint deliberately does NOT do this: not registering on
+# workers is the primary isolation control; the GENERACY_CLUSTER_ROLE=worker
+# refusal baked into `generacy cockpit mcp` is only defense-in-depth.
+#
+# Idempotent per the contract (#917 Q4-A — the entrypoint is the source of
+# truth; upgrades must self-heal, and hand-edits in a rebuildable container
+# aren't durable): a matching entry is a silent no-op; a stale/foreign entry is
+# overwritten unconditionally, each with one log line to stderr. Best-effort —
+# a failure warns but never bricks boot.
+node <<'NODE' || log "WARNING: cockpit MCP registration failed (see above) — /cockpit MCP tools may be unavailable in orchestrator sessions"
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const configPath = path.join(os.homedir(), '.claude.json');
+const DESIRED = { type: 'stdio', command: 'generacy', args: ['cockpit', 'mcp'] };
+
+let raw;
+try {
+  raw = fs.readFileSync(configPath, 'utf8');
+} catch (e) {
+  if (e.code === 'ENOENT') {
+    raw = '{}';
+  } else {
+    console.error('[entrypoint] ERROR reading ' + configPath + ': ' + e.message);
+    process.exit(1);
+  }
+}
+
+let config;
+try {
+  config = raw.trim() ? JSON.parse(raw) : {};
+} catch (e) {
+  // Never clobber an unparseable config we might be racing with — bail loudly.
+  console.error('[entrypoint] ERROR: ' + configPath + ' is not valid JSON; leaving it untouched (' + e.message + ')');
+  process.exit(1);
+}
+
+if (!config.mcpServers || typeof config.mcpServers !== 'object') {
+  config.mcpServers = {};
+}
+
+const existing = config.mcpServers.cockpit;
+// Compare only command + args per the contract (ignore extra fields like an
+// existing `type`), so a CLI-written-but-equivalent entry is left untouched.
+const argsMatch = existing
+  && Array.isArray(existing.args)
+  && existing.args.length === DESIRED.args.length
+  && existing.args.every((a, i) => a === DESIRED.args[i]);
+const isCurrent = existing && existing.command === DESIRED.command && argsMatch;
+
+if (isCurrent) {
+  process.exit(0); // Already correct — no-op, do not log.
+}
+
+const hadEntry = !!existing;
+let priorDesc = '';
+if (hadEntry) {
+  const parts = [];
+  if (typeof existing.command === 'string') parts.push(existing.command);
+  if (Array.isArray(existing.args)) parts.push(...existing.args.map(String));
+  priorDesc = parts.join(' ') || JSON.stringify(existing);
+}
+
+config.mcpServers.cockpit = DESIRED;
+// In-place write (O_TRUNC): ~/.claude.json is bind-mounted, so a rename-over
+// would break the mount. writeFileSync overwrites the same inode.
+fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+if (hadEntry) {
+  console.error('[entrypoint] reconciled cockpit MCP entry: prior command "' + priorDesc + '", now "generacy cockpit mcp"');
+} else {
+  console.error('[entrypoint] registered cockpit MCP server (user scope)');
+}
+NODE
+
 # Run generacy setup if CLI is available.
 # In wizard mode the workspace isn't cloned yet (credentials arrive post-activation),
 # so workspace/build steps are deferred to entrypoint-post-activation.sh.


### PR DESCRIPTION
Closes #75. Companion to generacy#917 FR-010 — the cockpit MCP server shipped there but is unreachable on clusters until this repo's orchestrator entrypoint registers it. Contract source of truth: `specs/917-improvement-spec-from-cockpit/contracts/entrypoint-registration.md` (generacy#917, merged in #922).

## Changes

1. **`.devcontainer/generacy/scripts/entrypoint-orchestrator.sh`** — register the cockpit MCP server at **user scope** for the orchestrator's Claude sessions. Runs *after* the shared-packages install + PATH export so the `generacy` binary the entry launches resolves (it's symlinked into `/usr/local/bin` for every shell, #73). Writes `~/.claude.json`'s `mcpServers.cockpit` key directly — equivalent to `claude mcp add --scope user cockpit -- generacy cockpit mcp`, but deterministic and independent of the `claude` CLI's add/overwrite exit semantics.
   - **Idempotent per the contract (Q4-A):**
     - matching entry → **silent no-op** (no log)
     - stale/foreign entry → **overwritten unconditionally** + `[entrypoint] reconciled cockpit MCP entry: prior command "<prior>", now "generacy cockpit mcp"`
     - absent → written + `[entrypoint] registered cockpit MCP server (user scope)`
   - Compares only `command` + `args` (ignores extra fields like an existing `type`), so a CLI-written-but-equivalent entry stays untouched.
   - Best-effort: a corrupt/unreadable `~/.claude.json` is **left untouched**, warns, and never bricks boot.
2. **`entrypoint-worker.sh`** — **unchanged** (verified zero diff). Not registering on workers is the primary isolation control; the `GENERACY_CLUSTER_ROLE=worker` refusal in `generacy cockpit mcp` is defense-in-depth.
3. **`.devcontainer/generacy/docker-compose.yml`** — set `GENERACY_CLUSTER_ROLE=orchestrator|worker` per service, mirroring the generacy scaffolder compose (#917 Q2-A). This compose and the scaffolder-generated one have silently diverged before — both now carry the var.

## Verification

- `bash -n entrypoint-orchestrator.sh` passes.
- `docker compose config` renders cleanly with `GENERACY_CLUSTER_ROLE: orchestrator` on the orchestrator and `: worker` on the worker.
- `entrypoint-worker.sh` has zero diff (no MCP-related lines added).
- Registration script driven through every idempotence case — absent→registered, current→no-op (no output), current+extra-field→no-op (extras kept), foreign→reconciled, no-file→created, no-`mcpServers`-key→registered, corrupt-JSON→untouched+exit 1 — all producing the exact contract log strings and preserving unrelated top-level keys (e.g. the existing `agency` entry).

## Acceptance criteria

- [x] Fresh cluster: orchestrator's `~/.claude.json` shows the `cockpit` entry; worker containers register none.
- [x] Re-running the entrypoint (restart) does not duplicate the entry; a stale/foreign entry is overwritten with a log line.
- [x] `GENERACY_CLUSTER_ROLE` present with the correct value in both services of the devcontainer compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)