### PR TITLE
fix: #78 gate cockpit MCP registration on the cockpit capability being installed

### DIFF
--- a/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
+++ b/.devcontainer/generacy/scripts/entrypoint-orchestrator.sh
@@ -175,19 +175,48 @@ export PATH="${SHARED_PACKAGES}/node_modules/.bin:${PATH}"
 # aren't durable): a matching entry is a silent no-op; a stale/foreign entry is
 # overwritten unconditionally, each with one log line to stderr. Best-effort —
 # a failure warns but never bricks boot.
-node <<'NODE' || log "WARNING: cockpit MCP registration failed (see above) — /cockpit MCP tools may be unavailable in orchestrator sessions"
+#
+# Gated on the cockpit capability actually being installed
+# (generacy-ai/cluster-base#78). On channels/points-in-time where the cockpit
+# subcommand isn't published yet (e.g. stable before 2026-07-13), `generacy
+# cockpit mcp` doesn't exist, so registering it unconditionally leaves a dead
+# MCP server that errors "unknown command 'cockpit'" on EVERY Claude session
+# start. Probe `generacy help cockpit` (commander's built-in help lookup: exit
+# 0 iff the `cockpit` command is registered) rather than the issue's suggested
+# `generacy cockpit --help` — the latter's `--help` short-circuits commander's
+# unknown-command error and exits 0 even when cockpit is absent, so it can't
+# distinguish present from absent. When the capability is ABSENT we don't
+# register, and we also REMOVE any stale cockpit entry so a downgrade/rollback
+# self-heals too. On a channel where cockpit IS installed, behavior is
+# unchanged (entry registered/reconciled).
+if generacy help cockpit >/dev/null 2>&1; then
+    COCKPIT_CAPABLE=1
+    log "cockpit capability present — reconciling cockpit MCP registration"
+else
+    COCKPIT_CAPABLE=0
+    log "cockpit capability absent on channel ${CHANNEL} — ensuring no stale cockpit MCP entry remains"
+fi
+
+COCKPIT_CAPABLE="$COCKPIT_CAPABLE" node <<'NODE' || log "WARNING: cockpit MCP registration failed (see above) — /cockpit MCP tools may be unavailable in orchestrator sessions"
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
 const configPath = path.join(os.homedir(), '.claude.json');
 const DESIRED = { type: 'stdio', command: 'generacy', args: ['cockpit', 'mcp'] };
+// Only register when the cockpit CLI is actually installed on this channel
+// (generacy-ai/cluster-base#78). When absent, remove any stale entry rather
+// than write/leave a dead one.
+const capable = process.env.COCKPIT_CAPABLE === '1';
 
 let raw;
 try {
   raw = fs.readFileSync(configPath, 'utf8');
 } catch (e) {
   if (e.code === 'ENOENT') {
+    // No config file yet. If cockpit isn't installed there's nothing to
+    // register and nothing to remove — a clean no-op.
+    if (!capable) process.exit(0);
     raw = '{}';
   } else {
     console.error('[entrypoint] ERROR reading ' + configPath + ': ' + e.message);
@@ -209,6 +238,21 @@ if (!config.mcpServers || typeof config.mcpServers !== 'object') {
 }
 
 const existing = config.mcpServers.cockpit;
+
+// Capability absent: `generacy cockpit mcp` can't start on this channel, so a
+// registered entry would be dead and error on every session. Remove any stale
+// entry (self-heals a downgrade/rollback) and never write a new one.
+if (!capable) {
+  if (!existing) process.exit(0); // Nothing registered — clean no-op.
+  delete config.mcpServers.cockpit;
+  // In-place write (O_TRUNC): ~/.claude.json is bind-mounted, so a rename-over
+  // would break the mount. writeFileSync overwrites the same inode.
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  console.error('[entrypoint] removed stale cockpit MCP entry (cockpit CLI not installed on this channel)');
+  process.exit(0);
+}
+
+// Capability present: reconcile toward DESIRED (existing self-heal semantics).
 // Compare only command + args per the contract (ignore extra fields like an
 // existing `type`), so a CLI-written-but-equivalent entry is left untouched.
 const argsMatch = existing


### PR DESCRIPTION
Closes #78.

## Problem

`entrypoint-orchestrator.sh` registered `mcpServers.cockpit` in `~/.claude.json` **unconditionally** (per the #917 Q4-A "entrypoint is the source of truth / upgrades self-heal" design). On any channel/point-in-time where the `cockpit` subcommand isn't published yet (observed on `stable` before cockpit landed on `@stable` 2026-07-13), `generacy cockpit mcp` doesn't exist — so the write left a dead MCP server that errored on **every** Claude session start:

```
Server stderr: error: unknown command 'cockpit'
Connection failed: MCP error -32000: Connection closed
```

## Fix

Gate the registration on a **capability probe**:

- **Capability present** → register/reconcile exactly as before (matching entry = silent no-op; stale/foreign entry = overwritten, one log line). Behavior on channels where cockpit is installed is **unchanged**.
- **Capability absent** → don't register, and **remove** any stale `cockpit` entry so a downgrade/rollback also self-heals. Other MCP servers are left untouched. This keeps #917 Q4-A intact while making "cockpit isn't on this channel" a clean no-op instead of per-session noise.

### Probe choice

I probe with `generacy help cockpit` (commander's built-in help lookup: exit `0` iff `cockpit` is a registered command) rather than the issue's suggested `generacy cockpit --help`. Testing against the real bin showed `--help` **short-circuits** commander's unknown-command error and exits `0` even when the command is absent — so it can't distinguish present from absent:

| Probe | cockpit present | cockpit absent |
|---|---|---|
| `generacy cockpit --help` | `rc 0` | `rc 0` ❌ |
| `generacy help cockpit` | `rc 0` | `rc 1` ✅ |

(`generacy cockpit mcp` can't be probed directly — invoking it starts the stdio server.) The issue explicitly permits "an equivalent capability probe".

## Acceptance criteria

- [x] On a channel where cockpit is **not** installed, the entrypoint leaves **no** `cockpit` MCP entry (removes a stale one, never writes a new one) → no cockpit MCP connection errors on session start.
- [x] On a channel where cockpit **is** installed, behavior is unchanged (registered/reconciled).

## Verification

Extracted the embedded node block and ran it across the full matrix — `{no config file, empty config, no cockpit key, already-correct, stale/foreign}` × `{capable, absent}` — plus an integrated probe+node smoke test with stubbed `generacy` binaries. All cases behaved as expected: capable registers/reconciles/no-ops; absent removes only the stale cockpit entry while preserving other MCP servers; unparseable config bails loudly and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)